### PR TITLE
[LYFT] [STRM-819] Add LyftProcessJobBundleFactory that spawns Python SDK harness processes directly.

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
@@ -59,6 +59,9 @@ public class DockerJobBundleFactory extends JobBundleFactoryBase {
           new JobBundleFactoryFactory() {
             @Override
             public JobBundleFactory create(JobInfo jobInfo) throws Exception {
+              if (System.getProperty("lyft.useDockerJobBundleFactory") == null) {
+                return LyftProcessJobBundleFactory.create(jobInfo);
+              }
               return new DockerJobBundleFactory(jobInfo);
             }
           });

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.fnexecution.control;
 
 import com.google.common.base.Preconditions;
@@ -21,6 +38,11 @@ import org.apache.beam.vendor.protobuf.v3.com.google.protobuf.util.JsonFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A {@link JobBundleFactory} that uses direct Python SDK harness environments. It assumes that all
+ * dependencies are present on the host machine and does not support artifact retrieval. In the
+ * Python development environment, simply run the JMV within the Python virtualenv.
+ */
 public class LyftProcessJobBundleFactory extends ProcessJobBundleFactory {
 
   /**

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
@@ -48,7 +48,8 @@ import org.slf4j.LoggerFactory;
 public class LyftProcessJobBundleFactory extends ProcessJobBundleFactory {
 
   /**
-   * Required since the super constructor calls getEnvironmentFactory the instance is initialized.
+   * Required since super constructor calls getEnvironmentFactory before instance is fully
+   * initialized.
    */
   private static ThreadLocal<JobInfo> JOB_INFO = new ThreadLocal<>();
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/LyftProcessJobBundleFactory.java
@@ -1,0 +1,147 @@
+package org.apache.beam.runners.fnexecution.control;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.environment.EnvironmentFactory;
+import org.apache.beam.runners.fnexecution.environment.ProcessEnvironment;
+import org.apache.beam.runners.fnexecution.environment.ProcessManager;
+import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.sdk.fn.IdGenerator;
+import org.apache.beam.vendor.protobuf.v3.com.google.protobuf.util.JsonFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LyftProcessJobBundleFactory extends ProcessJobBundleFactory {
+
+  /**
+   * Required since the super constructor calls getEnvironmentFactory the instance is initialized.
+   */
+  private static ThreadLocal<JobInfo> JOB_INFO = new ThreadLocal<>();
+
+  public static LyftProcessJobBundleFactory create(JobInfo jobInfo) throws Exception {
+    try {
+      JOB_INFO.set(jobInfo);
+      return new LyftProcessJobBundleFactory(jobInfo);
+    } finally {
+      JOB_INFO.remove();
+    }
+  }
+
+  private LyftProcessJobBundleFactory(JobInfo jobInfo) throws Exception {
+    super(jobInfo);
+  }
+
+  @Override
+  protected EnvironmentFactory getEnvironmentFactory(
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      ControlClientPool.Source clientSource,
+      IdGenerator idGenerator) {
+
+    return new LyftPythonEnvironmentFactory(
+        Preconditions.checkNotNull(JOB_INFO.get(), "jobInfo is null"),
+        controlServiceServer,
+        loggingServiceServer,
+        retrievalServiceServer,
+        provisioningServiceServer,
+        idGenerator,
+        clientSource);
+  }
+
+  private static class LyftPythonEnvironmentFactory implements EnvironmentFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(LyftPythonEnvironmentFactory.class);
+
+    private final JobInfo jobInfo;
+    private final ProcessManager processManager;
+    private final GrpcFnServer<FnApiControlClientPoolService> controlServiceServer;
+    private final GrpcFnServer<GrpcLoggingService> loggingServiceServer;
+    private final GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer;
+    private final GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer;
+    private final IdGenerator idGenerator;
+    private final ControlClientPool.Source clientSource;
+
+    private LyftPythonEnvironmentFactory(
+        JobInfo jobInfo,
+        GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+        GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+        GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+        GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+        IdGenerator idGenerator,
+        ControlClientPool.Source clientSource) {
+      this.jobInfo = jobInfo;
+      this.processManager = ProcessManager.create();
+      this.controlServiceServer = controlServiceServer;
+      this.loggingServiceServer = loggingServiceServer;
+      this.retrievalServiceServer = retrievalServiceServer;
+      this.provisioningServiceServer = provisioningServiceServer;
+      this.idGenerator = idGenerator;
+      this.clientSource = clientSource;
+    }
+
+    /** Creates a new, active {@link RemoteEnvironment} backed by a forked process. */
+    @Override
+    public RemoteEnvironment createEnvironment(RunnerApi.Environment environment) throws Exception {
+      String workerId = idGenerator.getId();
+
+      String pipelineOptionsJson = JsonFormat.printer().print(jobInfo.pipelineOptions());
+      HashMap<String, String> env = new HashMap<>();
+      env.put("WORKER_ID", workerId);
+      env.put("PIPELINE_OPTIONS", pipelineOptionsJson);
+      env.put(
+          "LOGGING_API_SERVICE_DESCRIPTOR",
+          loggingServiceServer.getApiServiceDescriptor().toString());
+      env.put(
+          "CONTROL_API_SERVICE_DESCRIPTOR",
+          controlServiceServer.getApiServiceDescriptor().toString());
+      env.put("SEMI_PERSISTENT_DIRECTORY", "/tmp");
+
+      String sdkHarnessEntrypoint = "apache_beam.runners.worker.sdk_worker_main";
+      String executable = "bash";
+      //List<String> args = ImmutableList.of("-c", String.format("'env; python -m %s'", sdkHarnessEntrypoint));
+      List<String> args =
+          ImmutableList.of("-c", String.format("env; python -m %s", sdkHarnessEntrypoint));
+
+      LOG.info("Creating Process with ID {}", workerId);
+      // Wrap the blocking call to clientSource.get in case an exception is thrown.
+      InstructionRequestHandler instructionHandler = null;
+      try {
+        processManager.startProcess(workerId, executable, args, env);
+        // Wait on a client from the gRPC server.
+        while (instructionHandler == null) {
+          try {
+            instructionHandler = clientSource.take(workerId, Duration.ofMinutes(2));
+          } catch (TimeoutException timeoutEx) {
+            LOG.info(
+                "Still waiting for startup of environment '{}' for worker id {}",
+                executable,
+                workerId);
+          } catch (InterruptedException interruptEx) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(interruptEx);
+          }
+        }
+      } catch (Exception e) {
+        try {
+          processManager.stopProcess(workerId);
+        } catch (Exception processKillException) {
+          e.addSuppressed(processKillException);
+        }
+        throw e;
+      }
+
+      return ProcessEnvironment.create(processManager, environment, workerId, instructionHandler);
+    }
+  }
+}


### PR DESCRIPTION
Currently it assumes that the JVM runs within the Python virtualenv and just starts the SDK harness. This works well in the development environment and we can refine as we get further with the Flink deployment side.
