### PR TITLE
[BEAM-5724] [STRM-1519] Create a fixed number of sdk_worker processes

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -33,7 +33,6 @@ import org.apache.beam.runners.fnexecution.jobsubmission.InMemoryJobService;
 import org.apache.beam.runners.fnexecution.jobsubmission.JobInvoker;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -90,9 +89,9 @@ public class FlinkJobServerDriver implements Runnable {
       name = "--sdk-worker-parallelism",
       usage = "Default parallelism for SDK worker processes (see portable pipeline options)"
     )
-    private Long sdkWorkerParallelism = 1L;
+    Long sdkWorkerParallelism = 1L;
 
-    public Long getSdkWorkerParallelism() {
+    Long getSdkWorkerParallelism() {
       return this.sdkWorkerParallelism;
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -90,9 +90,9 @@ public class FlinkJobServerDriver implements Runnable {
       name = "--sdk-worker-parallelism",
       usage = "Default parallelism for SDK worker processes (see portable pipeline options)"
     )
-    String sdkWorkerParallelism = PortablePipelineOptions.SDK_WORKER_PARALLELISM_PIPELINE;
+    private Long sdkWorkerParallelism = 1L;
 
-    String getSdkWorkerParallelism() {
+    public Long getSdkWorkerParallelism() {
       return this.sdkWorkerParallelism;
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Iterables;
 import com.lyft.streamingplatform.flink.FlinkLyftKinesisConsumer;
 import com.lyft.streamingplatform.flink.InitialRoundRobinKinesisShardAssigner;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.beam.model.pipeline.v1.RunnerApi;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContext.java
@@ -80,6 +80,18 @@ class FlinkDefaultExecutableStageContext implements FlinkExecutableStageContext,
     }
   }
 
-  static final Factory MULTI_INSTANCE_FACTORY =
-      (jobInfo) -> FlinkDefaultExecutableStageContext.create(jobInfo);
+  enum MultiInstanceFactory implements Factory {
+    MULTI_INSTANCE;
+
+    private static final ThreadLocal<ReferenceCountingFlinkExecutableStageContextFactory> threadFactories =
+        ThreadLocal.withInitial(() ->
+            ReferenceCountingFlinkExecutableStageContextFactory.create(
+                FlinkDefaultExecutableStageContext::create));
+
+
+    @Override
+    public FlinkExecutableStageContext get(JobInfo jobInfo) {
+      return threadFactories.get().get(jobInfo);
+    }
+  }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -41,7 +41,7 @@ public interface FlinkExecutableStageContext extends AutoCloseable {
     PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
     if (PortablePipelineOptions.SDK_WORKER_PARALLELISM_STAGE.equals(
         portableOptions.getSdkWorkerParallelism())) {
-      return FlinkDefaultExecutableStageContext.MULTI_INSTANCE_FACTORY;
+      return FlinkDefaultExecutableStageContext.MultiInstanceFactory.MULTI_INSTANCE;
     } else {
       return FlinkDefaultExecutableStageContext.ReferenceCountingFactory.REFERENCE_COUNTING;
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -17,9 +17,11 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
+import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
+import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
 import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
@@ -38,13 +40,7 @@ public interface FlinkExecutableStageContext extends AutoCloseable {
   }
 
   static Factory factory(FlinkPipelineOptions options) {
-    PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
-    if (PortablePipelineOptions.SDK_WORKER_PARALLELISM_STAGE.equals(
-        portableOptions.getSdkWorkerParallelism())) {
-      return FlinkDefaultExecutableStageContext.MultiInstanceFactory.MULTI_INSTANCE;
-    } else {
-      return FlinkDefaultExecutableStageContext.ReferenceCountingFactory.REFERENCE_COUNTING;
-    }
+    return MultiInstanceFactory.MULTI_INSTANCE;
   }
 
   StageBundleFactory getStageBundleFactory(ExecutableStage executableStage);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -17,14 +17,12 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
-import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
 import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
-import org.apache.beam.sdk.options.PortablePipelineOptions;
 
 /** The Flink context required in order to execute {@link ExecutableStage stages}. */
 public interface FlinkExecutableStageContext extends AutoCloseable {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
@@ -185,10 +185,11 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
   /**
    * {@link WrappedContext} does not expose equals of actual {@link FlinkExecutableStageContext}.
    */
-  private class WrappedContext implements FlinkExecutableStageContext {
+  @VisibleForTesting
+  class WrappedContext implements FlinkExecutableStageContext {
     private JobInfo jobInfo;
     private AtomicInteger referenceCount;
-    private FlinkExecutableStageContext context;
+    @VisibleForTesting FlinkExecutableStageContext context;
 
     /** {@link WrappedContext#equals(Object)} is only based on {@link JobInfo#jobId()}. */
     WrappedContext(JobInfo jobInfo, FlinkExecutableStageContext context) {

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.flink;
 
-import static org.apache.beam.sdk.options.PortablePipelineOptions.SDK_WORKER_PARALLELISM_PIPELINE;
-import static org.apache.beam.sdk.options.PortablePipelineOptions.SDK_WORKER_PARALLELISM_STAGE;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -46,7 +44,7 @@ public class FlinkJobServerDriverTest {
     assertThat(config.port, is(8099));
     assertThat(config.artifactPort, is(8098));
     assertThat(config.flinkMasterUrl, is("[auto]"));
-    assertThat(config.sdkWorkerParallelism, is(SDK_WORKER_PARALLELISM_PIPELINE));
+    assertThat(config.sdkWorkerParallelism, is(1));
     assertThat(config.cleanArtifactsPerJob, is(false));
     FlinkJobServerDriver flinkJobServerDriver = FlinkJobServerDriver.fromConfig(config);
     assertThat(flinkJobServerDriver, is(not(nullValue())));
@@ -63,14 +61,14 @@ public class FlinkJobServerDriverTest {
               "--artifact-port",
               "43",
               "--flink-master-url=jobmanager",
-              "--sdk-worker-parallelism=stage",
+              "--sdk-worker-parallelism=4",
               "--clean-artifacts-per-job",
             });
     assertThat(driver.configuration.host, is("test"));
     assertThat(driver.configuration.port, is(42));
     assertThat(driver.configuration.artifactPort, is(43));
     assertThat(driver.configuration.flinkMasterUrl, is("jobmanager"));
-    assertThat(driver.configuration.sdkWorkerParallelism, is(SDK_WORKER_PARALLELISM_STAGE));
+    assertThat(driver.configuration.sdkWorkerParallelism, is(4));
     assertThat(driver.configuration.cleanArtifactsPerJob, is(true));
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContextTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContextTest.java
@@ -1,0 +1,59 @@
+package org.apache.beam.runners.flink.translation.functions;
+
+import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
+import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
+import org.apache.beam.runners.flink.translation.functions.ReferenceCountingFlinkExecutableStageContextFactory.WrappedContext;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.vendor.protobuf.v3.com.google.protobuf.Struct;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FlinkDefaultExecutableStageContext}. */
+@RunWith(JUnit4.class)
+public class FlinkDefaultExecutableStageContextTest {
+  private static JobInfo constructJobInfo(long parallellism) {
+    PortablePipelineOptions portableOptions =
+        PipelineOptionsFactory.as(PortablePipelineOptions.class);
+    portableOptions.setSdkWorkerParallelism(parallellism);
+
+    Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);
+    return JobInfo.create("job-id", "job-name", "retrieval-token", pipelineOptions);
+  }
+
+  @Test
+  public void testMultiInstanceFactory() {
+    JobInfo jobInfo = constructJobInfo(2);
+
+    WrappedContext f1 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    WrappedContext f2 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    WrappedContext f3 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+
+    Assert.assertNotEquals("We should create two different factories", f1.context, f2.context);
+    Assert.assertEquals(
+        "Future calls should be round-robbined to those two factories", f1.context, f3.context);
+  }
+
+  @Test
+  public void testDefault() {
+    JobInfo jobInfo = constructJobInfo(0);
+
+    int expectedParallelism = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+
+    WrappedContext f1 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    for (int i = 1; i < expectedParallelism; i++) {
+      Assert.assertNotEquals(
+          "We should create " + expectedParallelism + " different factories",
+          f1.context,
+          ((WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo)).context);
+    }
+
+    Assert.assertEquals(
+        "Future calls should be round-robbined to those",
+        f1.context,
+        ((WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo)).context);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -73,20 +73,12 @@ public interface PortablePipelineOptions extends PipelineOptions {
 
   void setDefaultEnvironmentConfig(@Nullable String config);
 
-  String SDK_WORKER_PARALLELISM_PIPELINE = "pipeline";
-  String SDK_WORKER_PARALLELISM_STAGE = "stage";
-
   @Description(
-      "SDK worker/harness process parallelism. Currently supported options are "
-          + "<null> (let the runner decide) or '"
-          + SDK_WORKER_PARALLELISM_PIPELINE
-          + "' (single SDK harness process per pipeline and runner process) or '"
-          + SDK_WORKER_PARALLELISM_STAGE
-          + "' (separate SDK harness for every executable stage).")
+      "Sets the number of sdk worker processes that will run on each worker node.")
   @Nullable
-  String getSdkWorkerParallelism();
+  Long getSdkWorkerParallelism();
 
-  void setSdkWorkerParallelism(@Nullable String parallelism);
+  void setSdkWorkerParallelism(@Nullable Long parallelism);
 
   @Description("Duration in milliseconds for environment cache within a job. 0 means no caching.")
   @Default.Integer(0)
@@ -94,3 +86,4 @@ public interface PortablePipelineOptions extends PipelineOptions {
 
   void setEnvironmentCacheMillis(int environmentCacheMillis);
 }
+

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -74,7 +74,8 @@ public interface PortablePipelineOptions extends PipelineOptions {
   void setDefaultEnvironmentConfig(@Nullable String config);
 
   @Description(
-      "Sets the number of sdk worker processes that will run on each worker node.")
+      "Sets the number of sdk worker processes that will run on each worker node. Default is 1. If"
+          + " 0, it will be automatically set according to the number of CPU cores on the worker.")
   @Nullable
   Long getSdkWorkerParallelism();
 
@@ -86,4 +87,3 @@ public interface PortablePipelineOptions extends PipelineOptions {
 
   void setEnvironmentCacheMillis(int environmentCacheMillis);
 }
-


### PR DESCRIPTION
Changes the behavior of --sdk-worker-parallelism=stage to only create a fixed number of sdk workers (currently hard-coded to 16).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




