### PR TITLE
[STRM-1547] Add kinesis watermarking for beam

### DIFF
--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -87,7 +87,7 @@ dependencies {
   validatesRunner project(path: project.path, configuration: "shadow")
   //LYFT CUSTOM
   shadow "org.apache.flink:flink-connector-kafka-0.11_2.11:1.5-lyft20180920"
-  shadow "com.lyft:streamingplatform-kinesis:1.2.20181003"
+  shadow "com.lyft:streamingplatform-kinesis:1.2-SNAPSHOT"
 }
 
 class ValidatesRunnerConfig {

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -65,15 +65,11 @@ runShadow {
     args += ["--clean-artifacts-per-job"]
   if (project.hasProperty('flinkMasterUrl'))
     args += ["--flink-master-url=${project.property('flinkMasterUrl')}"]
-  if (project.hasProperty('sdkWorkerParallelism'))
-    args += ["--sdk-worker-parallelism=${project.property('sdkWorkerParallelism')}"]
 
   // Enable remote debugging.
   jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
   if (project.hasProperty("logLevel"))
     jvmArgs += ["-Dorg.slf4j.simpleLogger.defaultLogLevel=${project.property('logLevel')}"]
-  if (project.hasProperty('lyft.pythonWorkerCmd'))
-    jvmArgs += ["-Dlyft.pythonWorkerCmd=${project.property("lyft.pythonWorkerCmd")}"]
 }
 
 createPortableValidatesRunnerTask(

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -65,11 +65,15 @@ runShadow {
     args += ["--clean-artifacts-per-job"]
   if (project.hasProperty('flinkMasterUrl'))
     args += ["--flink-master-url=${project.property('flinkMasterUrl')}"]
+  if (project.hasProperty('sdkWorkerParallelism'))
+    args += ["--sdk-worker-parallelism=${project.property('sdkWorkerParallelism')}"]
 
   // Enable remote debugging.
   jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
   if (project.hasProperty("logLevel"))
     jvmArgs += ["-Dorg.slf4j.simpleLogger.defaultLogLevel=${project.property('logLevel')}"]
+  if (project.hasProperty('lyft.pythonWorkerCmd'))
+    jvmArgs += ["-Dlyft.pythonWorkerCmd=${project.property("lyft.pythonWorkerCmd")}"]
 }
 
 createPortableValidatesRunnerTask(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -71,7 +71,7 @@ public class LyftFlinkStreamingPortableTranslations {
   private static final String FLINK_KAFKA_URN = "lyft:flinkKafkaInput";
   private static final String FLINK_KINESIS_URN = "lyft:flinkKinesisInput";
   private static final String BYTES_ENCODING = "bytes";
-  private static final String LYFT_KINESIS_EVENT_ENCODING = "lyft_kinesis_event";
+  private static final String LYFT_KINESIS_EVENT_ENCODING = "lyft-kinesis-event";
 
   @AutoService(NativeTransforms.IsNativeTransform.class)
   public static class IsFlinkNativeTransform implements NativeTransforms.IsNativeTransform {
@@ -174,7 +174,7 @@ public class LyftFlinkStreamingPortableTranslations {
           stream = params.path("stream").textValue(), "'stream' needs to be set");
 
       String encoding = BYTES_ENCODING;
-      if (params.has("encoding")) {
+      if (params.hasNonNull("encoding")) {
         encoding = params.get("encoding").asText();
       }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -258,7 +258,7 @@ public class LyftFlinkStreamingPortableTranslations {
    * array of event objects. This schema tags events with the occurred_at time of the oldest event
    * in the message.
    *
-   * The output of this schema is utf-8 encoded json.
+   * This schema passes through the original message.
    */
   @VisibleForTesting
   static class LyftBase64ZlibJsonSchema
@@ -336,8 +336,7 @@ public class LyftFlinkStreamingPortableTranslations {
         }
       }
 
-      return WindowedValue.timestampedValueInGlobalWindow(
-          inflatedString.getBytes(Charset.forName("UTF-8")), new Instant(timestamp));
+      return WindowedValue.timestampedValueInGlobalWindow(recordValue, new Instant(timestamp));
     }
 
     @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -13,44 +13,44 @@ public class LyftFlinkStreamingPortableTranslationsTest {
 
   @Test
   public void testBeamKinesisSchema() throws IOException {
+    // [{"event_id": 1, "occurred_at": "2018-10-27 00:20:02.900"}]"
     byte[] message = Base64.getDecoder()
         .decode("eJyLrlZKLUvNK4nPTFGyUjDUUVDKT04uLSpKTYlPLAGKKBkZ"
             + "GFroGhroGpkrGBhYGRlYGRjpWRoYKNXGAgARiA/1");
 
     LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
     WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
-    Assert.assertEquals("[{\"event_id\": 1, \"occurred_at\": \"2018-10-27 00:20:02.900\"}]",
-        new String(value.getValue(), UTF_8));
 
+    Assert.assertArrayEquals(message, value.getValue());
     Assert.assertEquals(1540599602000L, value.getTimestamp().getMillis());
   }
 
   @Test
   public void testBeamKinesisSchemaNoTimestamp() throws IOException {
+    // [{"event_id": 1}]
     byte[] message = Base64.getDecoder()
         .decode("eJyLrlZKLUvNK4nPTFGyUjCsjQUANv8Fzg==");
 
     LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
     WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
-    Assert.assertEquals("[{\"event_id\": 1}]",
-        new String(value.getValue(), UTF_8));
 
+    Assert.assertArrayEquals(message, value.getValue());
     Assert.assertEquals(Long.MIN_VALUE, value.getTimestamp().getMillis());
   }
 
 
   @Test
   public void testBeamKinesisSchemaMultipleRecords() throws IOException {
+    // [{"event_id": 1, "occurred_at": "2018-10-27 00:20:02.900"},
+    //  {"event_id": 2, "occurred_at": "2018-10-27 00:38:13.005"}]
     byte[] message = Base64.getDecoder()
         .decode("eJyLrlZKLUvNK4nPTFGyUjDUUVDKT04uLSpKTYlPLAGKKBkZGFroGhroGpkr"
             + "GBhYGRlYGRjpWRoYKNXqKKBoNSKk1djCytBYz8DAVKk2FgC35B+F");
 
     LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
     WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
-    Assert.assertEquals("[{\"event_id\": 1, \"occurred_at\": \"2018-10-27 00:20:02.900\"}, "
-            + "{\"event_id\": 2, \"occurred_at\": \"2018-10-27 00:38:13.005\"}]",
-        new String(value.getValue(), UTF_8));
 
+    Assert.assertArrayEquals(message, value.getValue());
     // we should output the oldest timestamp in the bundle
     Assert.assertEquals(1540599602000L, value.getTimestamp().getMillis());
   }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -1,0 +1,58 @@
+package org.apache.beam.runners.flink;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.util.Base64;
+import org.apache.beam.runners.flink.LyftFlinkStreamingPortableTranslations.LyftBase64ZlibJsonSchema;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LyftFlinkStreamingPortableTranslationsTest {
+
+  @Test
+  public void testBeamKinesisSchema() throws IOException {
+    byte[] message = Base64.getDecoder()
+        .decode("eJyLrlZKLUvNK4nPTFGyUjDUUVDKT04uLSpKTYlPLAGKKBkZ"
+            + "GFroGhroGpkrGBhYGRlYGRjpWRoYKNXGAgARiA/1");
+
+    LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
+    WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
+    Assert.assertEquals("[{\"event_id\": 1, \"occurred_at\": \"2018-10-27 00:20:02.900\"}]",
+        new String(value.getValue(), UTF_8));
+
+    Assert.assertEquals(1540599602000L, value.getTimestamp().getMillis());
+  }
+
+  @Test
+  public void testBeamKinesisSchemaNoTimestamp() throws IOException {
+    byte[] message = Base64.getDecoder()
+        .decode("eJyLrlZKLUvNK4nPTFGyUjCsjQUANv8Fzg==");
+
+    LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
+    WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
+    Assert.assertEquals("[{\"event_id\": 1}]",
+        new String(value.getValue(), UTF_8));
+
+    Assert.assertEquals(Long.MIN_VALUE, value.getTimestamp().getMillis());
+  }
+
+
+  @Test
+  public void testBeamKinesisSchemaMultipleRecords() throws IOException {
+    byte[] message = Base64.getDecoder()
+        .decode("eJyLrlZKLUvNK4nPTFGyUjDUUVDKT04uLSpKTYlPLAGKKBkZGFroGhroGpkr"
+            + "GBhYGRlYGRjpWRoYKNXqKKBoNSKk1djCytBYz8DAVKk2FgC35B+F");
+
+    LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
+    WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
+    Assert.assertEquals("[{\"event_id\": 1, \"occurred_at\": \"2018-10-27 00:20:02.900\"}, "
+            + "{\"event_id\": 2, \"occurred_at\": \"2018-10-27 00:38:13.005\"}]",
+        new String(value.getValue(), UTF_8));
+
+    // we should output the oldest timestamp in the bundle
+    Assert.assertEquals(1540599602000L, value.getTimestamp().getMillis());
+  }
+
+}

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -10,12 +10,16 @@ from apache_beam.transforms.core import Windowing
 class FlinkKinesisInput(PTransform):
   """Custom transform that wraps a Flink Kinesis consumer - only works with the
   portable Flink runner."""
+
+  LYFT_BASE64_ZLIB_JSON_ENCODING = "lyft-base64-zlib-json"
+
   consumer_properties = {
     'aws.region': 'us-east-1',
     'flink.stream.initpos': 'TRIM_HORIZON'
   }
   stream = None
   encoding = None
+  max_out_of_orderness_millis = None
 
   def expand(self, pbegin):
     assert isinstance(pbegin, pvalue.PBegin), (
@@ -37,6 +41,7 @@ class FlinkKinesisInput(PTransform):
     return ("lyft:flinkKinesisInput", json.dumps({
       'stream': self.stream,
       'encoding': self.encoding,
+      'max_out_of_orderness_millis': self.max_out_of_orderness_millis,
       'properties': self.consumer_properties}))
 
   @staticmethod
@@ -47,6 +52,7 @@ class FlinkKinesisInput(PTransform):
     payload = json.loads(spec_parameter)
     instance.stream = payload['stream']
     instance.encoding = payload['encoding']
+    instance.max_out_of_orderness_millis = payload['max_out_of_orderness_millis']
     instance.consumer_properties = payload['properties']
     return instance
 
@@ -59,7 +65,23 @@ class FlinkKinesisInput(PTransform):
     return self
 
   def with_encoding(self, encoding):
+    """
+    Sets the encoding used for messages in the stream. This is required for
+    watermarks to be emitted. Currently supported encodings:
+
+    * FlinkKinesisInput.LYFT_BASE64_ZLIB_JSON_ENCODING
+    """
     self.encoding = encoding
+    return self
+
+  def with_max_out_of_orderness_millis(self, max_out_of_orderness_millis):
+    """
+    The interval between the maximum timestamp seen so far and the watermark that
+    is emitted. For example, if this is set to 1000ms, after seeing a record for
+    10:00:01 we will emit a watermark for 10:00:00, indicating that we believe that all
+    data from before that time has arrived.
+    """
+    self.max_out_of_orderness_millis = max_out_of_orderness_millis
     return self
 
   def with_endpoint(self, endpoint, access_key, secret_key):

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -46,6 +46,7 @@ class FlinkKinesisInput(PTransform):
     instance = FlinkKinesisInput()
     payload = json.loads(spec_parameter)
     instance.stream = payload['stream']
+    instance.encoding = payload['encoding']
     instance.consumer_properties = payload['properties']
     return instance
 
@@ -59,6 +60,7 @@ class FlinkKinesisInput(PTransform):
 
   def with_encoding(self, encoding):
     self.encoding = encoding
+    return self
 
   def with_endpoint(self, endpoint, access_key, secret_key):
     # cannot have both region and endpoint

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -15,6 +15,7 @@ class FlinkKinesisInput(PTransform):
     'flink.stream.initpos': 'TRIM_HORIZON'
   }
   stream = None
+  encoding = None
 
   def expand(self, pbegin):
     assert isinstance(pbegin, pvalue.PBegin), (
@@ -35,6 +36,7 @@ class FlinkKinesisInput(PTransform):
 
     return ("lyft:flinkKinesisInput", json.dumps({
       'stream': self.stream,
+      'encoding': self.encoding,
       'properties': self.consumer_properties}))
 
   @staticmethod
@@ -54,6 +56,9 @@ class FlinkKinesisInput(PTransform):
   def set_consumer_property(self, key, value):
     self.consumer_properties[key] = value
     return self
+
+  def with_encoding(self, encoding):
+    self.encoding = encoding
 
   def with_endpoint(self, endpoint, access_key, secret_key):
     # cannot have both region and endpoint


### PR DESCRIPTION
This PR adds support for watermarks in the kinesis source for beam pipelines. This requires parsing the messages, pulling out the occurred_at dates, marking those in the emitted WindowedValue, then producing watermarks from that.

To allow the kinesis source to still be used with non-lyft-event streams, I added a new "encoding" option to the Python kinesis client. By default it's `bytes`—i.e., non-interpretable by Java—but it can also be specified to be `lyft-kinesis-event`, in which case we'll parse the data, extract the timestamps, and emit watermarks. In this case, I also opted to outputting straight json to python instead of the compressed/base64-encoded form. This should make life a bit easier for pipeline authors as they will not need to do this on their end.

At this stage, I'm mostly looking for feedback on the overall approach. Some concrete questions:
* What should we send to python? This version is sending an array of utf-8 json events (as opposed to currently, where we send an zlib-compressed/base-64 encoded json array). Would it be desirable to break apart the array of events into individual messages?
* What code should live here versus streamingplatform?
* What should the maxOutOfOrderness be set to? Should this be configurable from python?

