### PR TITLE
Use loggedAt to replace future occurredAt timestamps

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -321,6 +321,10 @@ public class LyftFlinkStreamingPortableTranslations {
         throw new IOException("Events is not an array");
       }
 
+      // Determine the timestamp as minimum occurred_at of all contained events.
+      // For each event, attempt to extract occurred_at from either date string or number.
+      // Assume timestamp as logged_at, when occurred_at is an (invalid) future timestamp.
+
       Iterator<JsonNode> iter = events.elements();
       long timestamp = Long.MAX_VALUE;
       while (iter.hasNext()) {

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -17,8 +17,13 @@
  */
 package org.apache.beam.runners.flink;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
 import java.util.Base64;
+import java.util.TimeZone;
+import java.util.zip.Deflater;
 import org.apache.beam.runners.flink.LyftFlinkStreamingPortableTranslations.LyftBase64ZlibJsonSchema;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.junit.Assert;
@@ -59,8 +64,7 @@ public class LyftFlinkStreamingPortableTranslationsTest {
 
   @Test
   public void testBeamKinesisSchemaNoTimestamp() throws IOException {
-    // [{"event_id": 1}]
-    byte[] message = Base64.getDecoder().decode("eJyLrlZKLUvNK4nPTFGyUjCsjQUANv8Fzg==");
+    byte[] message = encode("[{\"event_id\": 1}]");
 
     LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
     WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
@@ -85,5 +89,37 @@ public class LyftFlinkStreamingPortableTranslationsTest {
     Assert.assertArrayEquals(message, value.getValue());
     // we should output the oldest timestamp in the bundle
     Assert.assertEquals(1540599602000L, value.getTimestamp().getMillis());
+  }
+
+  @Test
+  public void testBeamKinesisSchemaFutureOccurredAtTimestamp() throws Exception {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS");
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+    long loggedAtMillis = sdf.parse("2018-10-27 00:10:02.000000").getTime();
+    String events =
+        "[{\"event_id\": 1, \"occurred_at\": \"2018-10-27 00:20:02.900\", \"logged_at\": "
+            + loggedAtMillis / 1000
+            + "}]";
+    byte[] message = encode(events);
+    LyftBase64ZlibJsonSchema schema = new LyftBase64ZlibJsonSchema();
+    WindowedValue<byte[]> value = schema.deserialize(message, "", "", 0, "", "");
+
+    Assert.assertArrayEquals(message, value.getValue());
+    Assert.assertEquals(loggedAtMillis, value.getTimestamp().getMillis());
+  }
+
+  private static byte[] encode(String data) throws IOException {
+    Deflater deflater = new Deflater();
+    deflater.setInput(data.getBytes(Charset.defaultCharset()));
+    deflater.finish();
+    byte[] buf = new byte[4096];
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length())) {
+      while (!deflater.finished()) {
+        int count = deflater.deflate(buf);
+        bos.write(buf, 0, count);
+      }
+      return bos.toByteArray();
+    }
   }
 }


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




