### PR TITLE
[Lyft] Fix kafka consumer

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -118,8 +118,7 @@ public class LyftFlinkStreamingPortableTranslations {
         context
             .getExecutionEnvironment()
             .addSource(
-                new FlinkKafkaConsumer010<>(topic, new ByteArrayWindowedValueSchema(), properties)
-                    .setStartFromLatest(),
+                new FlinkKafkaConsumer010<>(topic, new ByteArrayWindowedValueSchema(), properties),
                 FlinkKafkaConsumer010.class.getSimpleName());
     context.addDataStream(Iterables.getOnlyElement(pTransform.getOutputsMap().values()), source);
   }


### PR DESCRIPTION
why?
 - Currently, Kafka consumer is explicitly setting the offset as `latest` it might not be a good fit for certain scenario. It should be flexible and provide consumer options to set the offset accordingly based on the configuration.

Here are the properties that can be used:
```
auto.offset.reset
```