### PR TITLE
Add option to disable the metric container accumulator

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -328,6 +328,7 @@ public class FlinkBatchPortablePipelineTranslator
     final FlinkExecutableStageFunction<InputT> function =
         new FlinkExecutableStageFunction<>(
             transform.getTransform().getUniqueName(),
+            context.getPipelineOptions(),
             stagePayload,
             context.getJobInfo(),
             outputMap,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -159,6 +159,15 @@ public interface FlinkPipelineOptions
 
   void setEnableMetrics(Boolean enableMetrics);
 
+  @Description(
+      "By default, uses Flink accumulators to store the metrics which allows to query metrics from the PipelineResult. "
+          + "If set to true, metrics will still be reported but can't be queried via PipelineResult. "
+          + "This saves network and memory.")
+  @Default.Boolean(false)
+  Boolean getDisableMetricAccumulator();
+
+  void setDisableMetricAccumulator(Boolean disableMetricAccumulator);
+
   /** Enables or disables externalized checkpoints. */
   @Description(
       "Enables or disables externalized checkpoints. "

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -46,6 +46,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Helper class for holding a {@link MetricsContainerImpl} and forwarding Beam metrics to Flink
  * accumulators and metrics.
+ *
+ * <p>Using accumulators can be turned off because it is memory and network intensive. The
+ * accumulator results are only meaningful in batch applications or testing streaming applications
+ * which have a defined end. They are not essential during execution because metrics will also be
+ * reported using the configured metrics reporter.
  */
 public class FlinkMetricContainer {
 
@@ -62,22 +67,27 @@ public class FlinkMetricContainer {
   private final Map<String, FlinkGauge> flinkGaugeCache;
   private final MetricsAccumulator metricsAccumulator;
 
-  public FlinkMetricContainer(RuntimeContext runtimeContext) {
+  public FlinkMetricContainer(RuntimeContext runtimeContext, boolean accumulatorDisabled) {
     this.runtimeContext = runtimeContext;
     this.flinkCounterCache = new HashMap<>();
     this.flinkDistributionGaugeCache = new HashMap<>();
     this.flinkGaugeCache = new HashMap<>();
 
-    Accumulator<MetricsContainerStepMap, MetricsContainerStepMap> metricsAccumulator =
-        runtimeContext.getAccumulator(ACCUMULATOR_NAME);
-    if (metricsAccumulator == null) {
+    Accumulator<MetricsContainerStepMap, MetricsContainerStepMap> metricsAccumulator;
+    if (accumulatorDisabled) {
+      // Do not register the accumulator with Flink
       metricsAccumulator = new MetricsAccumulator();
-      try {
-        runtimeContext.addAccumulator(ACCUMULATOR_NAME, metricsAccumulator);
-      } catch (UnsupportedOperationException e) {
-        // Not supported in all environments, e.g. tests
-      } catch (Exception e) {
-        LOG.error("Failed to create metrics accumulator.", e);
+    } else {
+      metricsAccumulator = runtimeContext.getAccumulator(ACCUMULATOR_NAME);
+      if (metricsAccumulator == null) {
+        metricsAccumulator = new MetricsAccumulator();
+        try {
+          runtimeContext.addAccumulator(ACCUMULATOR_NAME, metricsAccumulator);
+        } catch (UnsupportedOperationException e) {
+          // Not supported in all environments, e.g. tests
+        } catch (Exception e) {
+          LOG.error("Failed to create metrics accumulator.", e);
+        }
       }
     }
     this.metricsAccumulator = (MetricsAccumulator) metricsAccumulator;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/MetricsAccumulator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/MetricsAccumulator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.accumulators.SimpleAccumulator;
 
 /** Accumulator of {@link MetricsContainerStepMap}. */
 public class MetricsAccumulator implements SimpleAccumulator<MetricsContainerStepMap> {
+
   private MetricsContainerStepMap metricsContainers = new MetricsContainerStepMap();
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDoFnFunction.java
@@ -130,10 +130,14 @@ public class FlinkDoFnFunction<InputT, OutputT>
             doFnSchemaInformation,
             sideInputMapping);
 
-    if ((serializedOptions.get().as(FlinkPipelineOptions.class)).getEnableMetrics()) {
+    FlinkPipelineOptions pipelineOptions = serializedOptions.get().as(FlinkPipelineOptions.class);
+    if (pipelineOptions.getEnableMetrics()) {
       doFnRunner =
           new DoFnRunnerWithMetricsUpdate<>(
-              stepName, doFnRunner, new FlinkMetricContainer(getRuntimeContext()));
+              stepName,
+              doFnRunner,
+              new FlinkMetricContainer(
+                  getRuntimeContext(), pipelineOptions.getDisableMetricAccumulator()));
     }
 
     doFnRunner.startBundle();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkStatefulDoFnFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkStatefulDoFnFunction.java
@@ -156,10 +156,14 @@ public class FlinkStatefulDoFnFunction<K, V, OutputT>
             doFnSchemaInformation,
             sideInputMapping);
 
-    if ((serializedOptions.get().as(FlinkPipelineOptions.class)).getEnableMetrics()) {
+    FlinkPipelineOptions pipelineOptions = serializedOptions.get().as(FlinkPipelineOptions.class);
+    if (pipelineOptions.getEnableMetrics()) {
       doFnRunner =
           new DoFnRunnerWithMetricsUpdate<>(
-              stepName, doFnRunner, new FlinkMetricContainer(getRuntimeContext()));
+              stepName,
+              doFnRunner,
+              new FlinkMetricContainer(
+                  getRuntimeContext(), pipelineOptions.getDisableMetricAccumulator()));
     }
 
     doFnRunner.startBundle();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.flink.translation.wrappers;
 import java.io.IOException;
 import java.util.List;
 import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
 import org.apache.beam.runners.flink.metrics.ReaderInvocationUtil;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -67,7 +68,10 @@ public class SourceInputFormat<T> extends RichInputFormat<WindowedValue<T>, Sour
 
   @Override
   public void open(SourceInputSplit<T> sourceInputSplit) throws IOException {
-    FlinkMetricContainer metricContainer = new FlinkMetricContainer(getRuntimeContext());
+    FlinkMetricContainer metricContainer =
+        new FlinkMetricContainer(
+            getRuntimeContext(),
+            options.as(FlinkPipelineOptions.class).getDisableMetricAccumulator());
 
     readerInvoker = new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -440,7 +440,8 @@ public class DoFnOperator<InputT, OutputT> extends AbstractStreamOperator<Window
     doFnRunner = createWrappingDoFnRunner(doFnRunner);
 
     if (options.getEnableMetrics()) {
-      flinkMetricContainer = new FlinkMetricContainer(getRuntimeContext());
+      flinkMetricContainer =
+          new FlinkMetricContainer(getRuntimeContext(), options.getDisableMetricAccumulator());
       doFnRunner = new DoFnRunnerWithMetricsUpdate<>(stepName, doFnRunner, flinkMetricContainer);
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -216,7 +216,9 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
 
     context = ctx;
 
-    FlinkMetricContainer metricContainer = new FlinkMetricContainer(getRuntimeContext());
+    FlinkPipelineOptions options = serializedOptions.get().as(FlinkPipelineOptions.class);
+    FlinkMetricContainer metricContainer =
+        new FlinkMetricContainer(getRuntimeContext(), options.getDisableMetricAccumulator());
 
     ReaderInvocationUtil<OutputT, UnboundedSource.UnboundedReader<OutputT>> readerInvoker =
         new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -91,6 +91,8 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getExecutionModeForBatch(), is(ExecutionMode.PIPELINED.name()));
     assertThat(options.getSavepointPath(), is(nullValue()));
     assertThat(options.getAllowNonRestoredState(), is(false));
+    assertThat(options.getEnableMetrics(), is(true));
+    assertThat(options.getDisableMetricAccumulator(), is(false));
   }
 
   @Test(expected = Exception.class)

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -21,6 +21,8 @@ import static org.apache.beam.runners.flink.metrics.FlinkMetricContainer.getFlin
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
@@ -57,15 +59,27 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link FlinkMetricContainer}. */
+@RunWith(Parameterized.class)
 public class FlinkMetricContainerTest {
+
+  @Parameter public boolean useMetricAccumulator;
 
   @Mock private RuntimeContext runtimeContext;
   @Mock private MetricGroup metricGroup;
+
+  FlinkMetricContainer container;
+
+  @Parameters(name = "useMetricAccumulator: {0}")
+  public static Object[] data() {
+    return new Object[] {true, false};
+  }
 
   @Before
   public void beforeTest() {
@@ -74,6 +88,7 @@ public class FlinkMetricContainerTest {
             anyString()))
         .thenReturn(new MetricsAccumulator());
     when(runtimeContext.getMetricGroup()).thenReturn(metricGroup);
+    container = new FlinkMetricContainer(runtimeContext, !useMetricAccumulator);
   }
 
   @Test
@@ -88,7 +103,6 @@ public class FlinkMetricContainerTest {
     SimpleCounter flinkCounter = new SimpleCounter();
     when(metricGroup.counter("namespace.name")).thenReturn(flinkCounter);
 
-    FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
     MetricName metricName = MetricName.named("namespace", "name");
     Counter counter = step.getCounter(metricName);
@@ -106,7 +120,6 @@ public class FlinkMetricContainerTest {
         new FlinkMetricContainer.FlinkGauge(GaugeResult.empty());
     when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
 
-    FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
     MetricName metricName = MetricName.named("namespace", "name");
     Gauge gauge = step.getGauge(metricName);
@@ -122,8 +135,6 @@ public class FlinkMetricContainerTest {
 
   @Test
   public void testMonitoringInfoUpdate() {
-    FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
-
     SimpleCounter userCounter = new SimpleCounter();
     when(metricGroup.counter("ns1.metric1")).thenReturn(userCounter);
 
@@ -173,8 +184,7 @@ public class FlinkMetricContainerTest {
 
   @Test
   public void testDropUnexpectedMonitoringInfoTypes() {
-    FlinkMetricContainer flinkContainer = new FlinkMetricContainer(runtimeContext);
-    MetricsContainerImpl step = flinkContainer.getMetricsContainer("step");
+    MetricsContainerImpl step = container.getMetricsContainer("step");
 
     MonitoringInfo intCounter =
         MonitoringInfo.newBuilder()
@@ -237,7 +247,7 @@ public class FlinkMetricContainerTest {
     SimpleCounter counter = new SimpleCounter();
     when(metricGroup.counter("ns1.int_counter")).thenReturn(counter);
 
-    flinkContainer.updateMetrics(
+    container.updateMetrics(
         "step", ImmutableList.of(intCounter, doubleCounter, intDistribution, doubleDistribution));
 
     // Flink's MetricGroup should only have asked for one counter (the integer-typed one) to be
@@ -280,7 +290,6 @@ public class FlinkMetricContainerTest {
         new FlinkMetricContainer.FlinkDistributionGauge(DistributionResult.IDENTITY_ELEMENT);
     when(metricGroup.gauge(eq("namespace.name"), anyObject())).thenReturn(flinkGauge);
 
-    FlinkMetricContainer container = new FlinkMetricContainer(runtimeContext);
     MetricsContainer step = container.getMetricsContainer("step");
     MetricName metricName = MetricName.named("namespace", "name");
     Distribution distribution = step.getDistribution(metricName);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
@@ -41,6 +41,8 @@ import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.join.RawUnionValue;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
@@ -256,9 +258,10 @@ public class FlinkExecutableStageFunctionTest {
     FlinkExecutableStageContextFactory contextFactory =
         Mockito.mock(FlinkExecutableStageContextFactory.class);
     when(contextFactory.get(any())).thenReturn(stageContext);
+    PipelineOptions options = PipelineOptionsFactory.create();
     FlinkExecutableStageFunction<Integer> function =
         new FlinkExecutableStageFunction<>(
-            "step", stagePayload, jobInfo, outputMap, contextFactory, null);
+            "step", options, stagePayload, jobInfo, outputMap, contextFactory, null);
     function.setRuntimeContext(runtimeContext);
     Whitebox.setInternalState(function, "stateRequestHandler", stateRequestHandler);
     return function;


### PR DESCRIPTION
This was observed via `500 Internal Server` errors when viewing jobs in the web
frontend. The Beam metric container does not only report metrics but also stores
them as Flink accumulators. With over a thousand tasks and many built-in Beam
metrics, this can accumulate to over 100MB of serialized data which is stored in
the JobManager's ExecutionGraph. This then fails to even sent over the wire due
to the `akka.framesize` limit. This introduces an option to disable the
reporting via accumulators. We don't need it and it adds a lot of runtime
overhead.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

