### PR TITLE
[STRMCMP-947] Using Kafka builders

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -177,9 +177,17 @@ dependencies {
   if (flink_version.startsWith('1.10')) {
       compile "org.apache.flink:flink-connector-kafka-0.11_2.11:1.10-lyft20200508"
       compile "com.lyft:streamingplatform-kinesis:2.1-SNAPSHOT"
+      compile("com.lyft:streamingplatform-kafka:2.1-SNAPSHOT") {
+        exclude group: "org.apache.flink", module: "flink-connector-kafka-0.11_2.11"
+        exclude group: "org.apache.flink", module: "flink-streaming-java_2.11"
+      }
   } else {
       compile "org.apache.flink:flink-connector-kafka-0.11_2.11:1.8-lyft20190924"
       compile "com.lyft:streamingplatform-kinesis:1.4-SNAPSHOT"
+      compile("com.lyft:streamingplatform-kafka:1.4-SNAPSHOT") {
+        exclude group: "org.apache.flink", module: "flink-connector-kafka-0.11_2.11"
+        exclude group: "org.apache.flink", module: "flink-streaming-java_2.11"
+      }
   }
 }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -17,19 +17,60 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.Base64;
+import java.util.Properties;
 import java.util.TimeZone;
 import java.util.zip.Deflater;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.flink.LyftFlinkStreamingPortableTranslations.LyftBase64ZlibJsonSchema;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer011;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer011;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
+/** Tests for {@link LyftFlinkStreamingPortableTranslations}. */
 public class LyftFlinkStreamingPortableTranslationsTest {
+
+  @Mock
+  private FlinkStreamingPortablePipelineTranslator.StreamingTranslationContext streamingContext;
+
+  @Mock private StreamExecutionEnvironment streamingEnvironment;
+
+  @Mock private DataStream dataStream;
+
+  @Mock private SingleOutputStreamOperator outputStreamOperator;
+
+  @Mock private DataStreamSink streamSink;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    when(streamingContext.getExecutionEnvironment()).thenReturn(streamingEnvironment);
+  }
 
   @Test
   public void testBeamKinesisSchema() throws IOException {
@@ -121,5 +162,169 @@ public class LyftFlinkStreamingPortableTranslationsTest {
       }
       return bos.toByteArray();
     }
+  }
+
+  @Test
+  public void testKafkaInputWithDevKafkaBroker() throws JsonProcessingException {
+
+    String id = "1";
+    String topicName = "kinesis_to_kafka";
+    String bootstrapServer = "localhost:9093";
+
+    byte[] payload = createPayload(topicName, bootstrapServer, true, false);
+    runAndAssertKafkaInput(id, topicName, payload);
+  }
+
+  @Test
+  public void testKafkaInputWithNonDevKafkaBroker() throws JsonProcessingException {
+
+    String id = "1";
+    String topicName = "kinesis_to_kafka";
+    String bootstrapServer = "staging-hdd.lyft.net";
+
+    byte[] payload = createPayload(topicName, bootstrapServer, true, true);
+    runAndAssertKafkaInput(id, topicName, payload);
+  }
+
+  private void runAndAssertKafkaInput(String id, String topicName, byte[] payload) {
+
+    RunnerApi.Pipeline pipeline = createPipeline(id, payload);
+
+    // run
+    new LyftFlinkStreamingPortableTranslations()
+        .translateKafkaInput(id, pipeline, streamingContext);
+
+    // assert
+    ArgumentCaptor<FlinkKafkaConsumer011> kafkaSourceCaptor =
+        ArgumentCaptor.forClass(FlinkKafkaConsumer011.class);
+    ArgumentCaptor<String> kafkaSourceNameCaptor = ArgumentCaptor.forClass(String.class);
+    verify(streamingEnvironment)
+        .addSource(kafkaSourceCaptor.capture(), kafkaSourceNameCaptor.capture());
+    Assert.assertEquals(
+        WindowedValue.class, kafkaSourceCaptor.getValue().getProducedType().getTypeClass());
+    Assert.assertTrue(kafkaSourceNameCaptor.getValue().contains(topicName));
+  }
+
+  @Test
+  public void shouldFailForMissingGroupIdToKafkaInput() throws JsonProcessingException {
+
+    LyftFlinkStreamingPortableTranslations portableTranslations =
+        new LyftFlinkStreamingPortableTranslations();
+    String id = "1";
+    String topicName = "kinesis_to_kafka";
+    String bootstrapServer = "test-hdd.lyft.com";
+
+    byte[] payload = createPayload(topicName, bootstrapServer, false, false);
+    RunnerApi.Pipeline pipeline = createPipeline(id, payload);
+
+    NullPointerException npe =
+        assertThrows(
+            NullPointerException.class,
+            () -> portableTranslations.translateKafkaInput(id, pipeline, streamingContext));
+    Assert.assertTrue(npe.getMessage().contains("group.id is a required property"));
+  }
+
+  @Test
+  public void testKafkaSinkForNonDevBroker() throws JsonProcessingException {
+
+    String id = "1";
+    String topicName = "kinesis_to_kafka";
+    String bootstrapServers = "test-hdd.lyft.com,test-hdd1.lyft.com:9093";
+    byte[] payload = createPayload(topicName, bootstrapServers, false, true);
+
+    runAndAssertKafkaSink(id, topicName, payload);
+  }
+
+  @Test
+  public void testKafkaSinkForDevBroker() throws JsonProcessingException {
+
+    String id = "1";
+    String topicName = "kinesis_to_kafka";
+    String bootstrapServer = "kafka-server.devbox.lyft.net";
+    byte[] payload = createPayload(topicName, bootstrapServer, false, false);
+
+    runAndAssertKafkaSink(id, topicName, payload);
+  }
+
+  private void runAndAssertKafkaSink(String id, String topicName, byte[] payload) {
+
+    RunnerApi.Pipeline pipeline = createPipeline(id, payload);
+    LyftFlinkStreamingPortableTranslations portableTranslations =
+        new LyftFlinkStreamingPortableTranslations();
+    when(outputStreamOperator.addSink(any())).thenReturn(streamSink);
+    when(dataStream.transform(anyString(), any(), any(OneInputStreamOperator.class)))
+        .thenReturn(outputStreamOperator);
+    when(streamingContext.getDataStreamOrThrow("fake_pcollection_id")).thenReturn(dataStream);
+
+    // run
+    portableTranslations.translateKafkaSink(id, pipeline, streamingContext);
+
+    // assert
+    verify(streamingContext).getDataStreamOrThrow("fake_pcollection_id");
+    verify(dataStream).transform(anyString(), any(), any(OneInputStreamOperator.class));
+    ArgumentCaptor<FlinkKafkaProducer011> kafkaSinkCaptor =
+        ArgumentCaptor.forClass(FlinkKafkaProducer011.class);
+    ArgumentCaptor<String> kafkaSinkNameCaptor = ArgumentCaptor.forClass(String.class);
+    verify(streamSink).name(kafkaSinkNameCaptor.capture());
+    verify(outputStreamOperator).addSink(kafkaSinkCaptor.capture());
+
+    Assert.assertTrue(kafkaSinkNameCaptor.getValue().contains(topicName));
+    Assert.assertEquals(FlinkKafkaProducer011.class, kafkaSinkCaptor.getValue().getClass());
+  }
+
+  /**
+   * utility method to create payload for tests.
+   *
+   * @param topicName name of the topic
+   * @param bootstrapServers bootstrap server
+   * @param withGroupId if {@code true}, include group.id to properties
+   * @param withCredentials if {@code true}, include username/password to properties.
+   * @return byte[]
+   * @throws JsonProcessingException
+   */
+  private byte[] createPayload(
+      String topicName, String bootstrapServers, boolean withGroupId, boolean withCredentials)
+      throws JsonProcessingException {
+
+    Properties properties = new Properties();
+    properties.put("bootstrap.servers", bootstrapServers);
+    if (withGroupId) {
+      properties.put("group.id", String.format("%s_%s", topicName, System.currentTimeMillis()));
+    }
+
+    ImmutableMap.Builder<String, Object> builder =
+        ImmutableMap.<String, Object>builder()
+            .put("topic", topicName)
+            .put("properties", properties);
+
+    if (withCredentials) {
+      builder.put("username", "kinesis_to_kafka").put("password", "abcde1234");
+    }
+
+    return new ObjectMapper().writeValueAsBytes(builder.build());
+  }
+
+  /**
+   * Creates a new {@link RunnerApi.Pipeline} with payload.
+   *
+   * @param id
+   * @param payload
+   * @return
+   */
+  private RunnerApi.Pipeline createPipeline(String id, byte[] payload) {
+
+    RunnerApi.PTransform pTransform =
+        RunnerApi.PTransform.newBuilder()
+            .putOutputs("fake_output_name", "fake_pcollection_id")
+            .putInputs("fake_input_name", "fake_pcollection_id")
+            .setSpec(RunnerApi.FunctionSpec.newBuilder().setPayload(ByteString.copyFrom(payload)))
+            .build();
+
+    RunnerApi.Pipeline pipeline =
+        RunnerApi.Pipeline.newBuilder()
+            .setComponents(RunnerApi.Components.newBuilder().putTransforms(id, pTransform).build())
+            .build();
+
+    return pipeline;
   }
 }

--- a/sdks/python/apache_beam/io/lyft/kafka.py
+++ b/sdks/python/apache_beam/io/lyft/kafka.py
@@ -13,6 +13,8 @@ class FlinkKafkaInput(PTransform):
   portable Flink runner."""
   consumer_properties = {'bootstrap.servers': 'localhost:9092'}
   topic = None
+  username = None
+  password = None
   max_out_of_orderness_millis = None
   start_from_timestamp_millis = None
 
@@ -37,7 +39,9 @@ class FlinkKafkaInput(PTransform):
       'topic': self.topic,
       'max_out_of_orderness_millis': self.max_out_of_orderness_millis,
       'start_from_timestamp_millis': self.start_from_timestamp_millis,
-      'properties': self.consumer_properties}))
+      'properties': self.consumer_properties,
+      'username': self.username,
+      'password': self.password}))
 
   @staticmethod
   @PTransform.register_urn("lyft:flinkKafkaInput", None)
@@ -49,6 +53,8 @@ class FlinkKafkaInput(PTransform):
     instance.max_out_of_orderness_millis = payload['max_out_of_orderness_millis']
     instance.start_from_timestamp_millis = payload['start_from_timestamp_millis']
     instance.consumer_properties = payload['properties']
+    instance.username = payload['username']
+    instance.password = payload['password']
     return instance
 
   def with_topic(self, topic):
@@ -86,6 +92,20 @@ class FlinkKafkaInput(PTransform):
     self.start_from_timestamp_millis = start_from_timestamp_millis
     return self
 
+  def with_username(self, username):
+    """
+    The username to consume data from Kafka.
+    """
+    self.username = username
+    return self
+
+  def with_password(self, password):
+    """
+    The password/credential to consume data from Kafka.
+    """
+    self.password = password
+    return self
+
 @beam.typehints.with_input_types(bytes)
 class FlinkKafkaSink(PTransform):
   """
@@ -107,6 +127,8 @@ class FlinkKafkaSink(PTransform):
   """
   producer_properties = {'bootstrap.servers': 'localhost:9092'}
   topic = None
+  username = None
+  password = None
 
   def expand(self, pcoll):
     self._check_pcollection(pcoll)
@@ -123,7 +145,9 @@ class FlinkKafkaSink(PTransform):
 
     return ("lyft:flinkKafkaSink", json.dumps({
       'topic': self.topic,
-      'properties': self.producer_properties}))
+      'properties': self.producer_properties,
+      'username': self.username,
+      'password': self.password}))
 
   @staticmethod
   @PTransform.register_urn("lyft:flinkKafkaSink", None)
@@ -133,6 +157,8 @@ class FlinkKafkaSink(PTransform):
     payload = json.loads(spec_parameter)
     instance.topic = payload['topic']
     instance.producer_properties = payload['properties']
+    instance.username = payload['username']
+    instance.password = payload['password']
     return instance
 
   def with_topic(self, topic):
@@ -146,3 +172,17 @@ class FlinkKafkaSink(PTransform):
   def with_bootstrap_servers(self, bootstrap_servers):
     return self.set_kafka_producer_property('bootstrap.servers',
                                             bootstrap_servers)
+
+  def with_username(self, username):
+    """
+    The username to write data to Kafka.
+    """
+    self.username = username
+    return self
+
+  def with_password(self, password):
+    """
+    The password/credential to write data to Kafka.
+    """
+    self.password = password
+    return self


### PR DESCRIPTION
The PR does the following

1. Refactors the Kafka Producer and Consumer code to leverage the new Builders provided within Streamingplatform core.  

Tested this code with beamperfk8s # kafka_produce_consume http://beamperfk8s1.ingress.semistateful-stg-0.us-east-1.k8s.lyft.net/#/job/9b5f556eb9a71f3839559effa5ce2523/overview.

