### PR TITLE
Fixing broken build because of conflicting version

### DIFF
--- a/model/fn-execution/build.gradle
+++ b/model/fn-execution/build.gradle
@@ -30,4 +30,5 @@ dependencies {
   // export the shaded variant as the actual runtime dependency.
   compile project(path: ":model:pipeline", configuration: "unshaded")
   runtime project(path: ":model:pipeline", configuration: "shadow")
+  errorprone("com.google.errorprone:error_prone_core:2.3.3")
 }

--- a/model/job-management/build.gradle
+++ b/model/job-management/build.gradle
@@ -32,4 +32,5 @@ dependencies {
   // export the shaded variant as the actual runtime dependency.
   compile project(path: ":model:pipeline", configuration: "unshaded")
   runtime project(path: ":model:pipeline", configuration: "shadow")
+  errorprone("com.google.errorprone:error_prone_core:2.3.3")
 }

--- a/model/pipeline/build.gradle
+++ b/model/pipeline/build.gradle
@@ -32,3 +32,7 @@ configurations {
 artifacts {
     unshaded jar
 }
+
+dependencies {
+    errorprone("com.google.errorprone:error_prone_core:2.3.3")
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
 
 public class LyftFlinkStreamingPortableTranslations {
 
-  private static final Logger logger =
+  private static final Logger LOG =
       LoggerFactory.getLogger(LyftFlinkStreamingPortableTranslations.class.getName());
 
   private static final String FLINK_KAFKA_URN = "lyft:flinkKafkaInput";
@@ -125,7 +125,7 @@ public class LyftFlinkStreamingPortableTranslations {
     final Properties properties = new Properties();
     properties.putAll(consumerProps);
 
-    logger.info("Kafka consumer for topic {} with properties {}", topic, properties);
+    LOG.info("Kafka consumer for topic {} with properties {}", topic, properties);
 
     FlinkKafkaConsumer011<WindowedValue<byte[]>> kafkaSource =
         new FlinkKafkaConsumer011<>(topic, new ByteArrayWindowedValueSchema(), properties);
@@ -212,7 +212,7 @@ public class LyftFlinkStreamingPortableTranslations {
       throw new RuntimeException("Could not parse KafkaConsumer properties.", e);
     }
 
-    logger.info("Kafka producer for topic {} with properties {}", topic, properties);
+    LOG.info("Kafka producer for topic {} with properties {}", topic, properties);
 
     String inputCollectionId = Iterables.getOnlyElement(pTransform.getInputsMap().values());
     DataStream<WindowedValue<byte[]>> inputDataStream =
@@ -313,7 +313,7 @@ public class LyftFlinkStreamingPortableTranslations {
           throw new IllegalArgumentException("Unknown encoding '" + encoding + "'");
       }
 
-      logger.info(
+      LOG.info(
           "Kinesis consumer for stream {} with properties {} and encoding {}",
           stream,
           properties,


### PR DESCRIPTION
There was an incompatible version of `errorprone` being used which was causing the build to break. 
This PR includes
1. Fixes for the older version of errorprone 2.3.3
2. Fixes for checkstyle issues