### PR TITLE
[STRMCMP-995] Adding a composite transform for S3 and kinesis inputs

### DIFF
--- a/sdks/python/apache_beam/io/lyft/s3_and_kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/s3_and_kinesis.py
@@ -1,0 +1,45 @@
+import json
+import logging
+
+from apache_beam import PTransform
+from apache_beam.pvalue import PBegin
+from apache_beam.pvalue import PCollection
+from apache_beam.transforms.core import Windowing
+from apache_beam.transforms.window import GlobalWindows
+
+
+class S3AndKinesisInput(PTransform):
+    """Custom composite transform that uses Kinesis and S3 as
+    input sources. This wraps the streamingplatform-dryft-sdk SourceConnector.
+    Only works with the portable Flink runner.
+    """
+
+    def expand(self, pbegin):
+        assert isinstance(pbegin, PBegin), (
+                'Input to transform must be a PBegin but found %s' % pbegin)
+        return PCollection(pbegin.pipeline)
+
+    def get_windowing(self, inputs):
+        return Windowing(GlobalWindows())
+
+    def with_program_config(self, program_config_path):
+        self.program_config_path = program_config_path
+        return self
+
+    @staticmethod
+    @PTransform.register_urn("lyft:flinkS3AndKinesisInput", None)
+    def from_runner_api_parameter(_unused_ptransform, spec_parameter, _unused_context):
+        logging.info("S3AndKinesis spec :" + spec_parameter)
+        instance = S3AndKinesisInput()
+        payload = json.loads(spec_parameter)
+        instance.program_config_path = payload['program_config_path']
+        return instance
+
+    def to_runner_api_parameter(self, _unused_context):
+        assert isinstance(self, S3AndKinesisInput), \
+            "expected instact of S3AndKinesisInput, but got %s" % self.__class__
+        assert self.program_config_path is not None, "Program config file path not set"
+
+        return ("lyft:flinkS3AndKinesisInput", json.dumps({
+            'program_config_path': self.program_config_path
+        }))


### PR DESCRIPTION
Adding a new composite transform which would be used to add inputs from both kinesis and S3.
I will add another PR which contains the changes to `LyftFlinkStreamingPortableTranslations`

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

