### PR TITLE
[STRMCMP-996] [LYFT] Adding translations for S3 and kinesis input sources

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -152,6 +152,25 @@ dependencies {
   compile "org.apache.flink:flink-metrics-core:$flink_version"
   compile "org.apache.flink:flink-java:$flink_version"
   compile "org.apache.flink:flink-runtime_2.11:$flink_version"
+  compile("com.lyft:streamingplatform-events-source:2.1-dryft-SNAPSHOT") {
+    exclude group: "com.lyft", module: "streamingplatform-kinesis"
+    exclude group: "com.google.guava", module: "guava"
+    exclude group: "com.google.protobuf", module: "protobuf-java"
+    exclude group: "co.cask.tephra", module: "tephra-api"
+    exclude group: "co.cask.tephra", module: "tephra-core"
+    exclude group: "co.cask.tephra", module: "tephra-hbase-compat-1.0"
+    exclude group: "com.jolbox", module: "bonecp"
+    exclude group: "com.zaxxer", module: "HikariCP"
+    exclude group: "javolution", module: "javolution"
+    exclude group: "org.antlr", module: "antlr-runtime"
+    exclude group: "org.apache.hadoop", module: "hadoop-common"
+    exclude group: "org.apache.hadoop", module: "hadoop-hdfs"
+    exclude group: "org.apache.hadoop", module: "hadoop-mapreduce-client-core"
+    exclude group: "org.apache.hbase", module: "hbase-client"
+    exclude group: "org.datanucleus", module: "datanucleus-api-jdo"
+    exclude group: "org.datanucleus", module: "datanucleus-core"
+    exclude group: "org.datanucleus", module: "datanucleus-rdbms"
+  }
   compile "org.apache.flink:flink-streaming-java_2.11:$flink_version"
   testCompile project(path: ":sdks:java:core", configuration: "shadowTest")
   // FlinkStateInternalsTest extends abstract StateInternalsTest

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -152,25 +152,6 @@ dependencies {
   compile "org.apache.flink:flink-metrics-core:$flink_version"
   compile "org.apache.flink:flink-java:$flink_version"
   compile "org.apache.flink:flink-runtime_2.11:$flink_version"
-  compile("com.lyft:streamingplatform-events-source:2.1-dryft-SNAPSHOT") {
-    exclude group: "com.lyft", module: "streamingplatform-kinesis"
-    exclude group: "com.google.guava", module: "guava"
-    exclude group: "com.google.protobuf", module: "protobuf-java"
-    exclude group: "co.cask.tephra", module: "tephra-api"
-    exclude group: "co.cask.tephra", module: "tephra-core"
-    exclude group: "co.cask.tephra", module: "tephra-hbase-compat-1.0"
-    exclude group: "com.jolbox", module: "bonecp"
-    exclude group: "com.zaxxer", module: "HikariCP"
-    exclude group: "javolution", module: "javolution"
-    exclude group: "org.antlr", module: "antlr-runtime"
-    exclude group: "org.apache.hadoop", module: "hadoop-common"
-    exclude group: "org.apache.hadoop", module: "hadoop-hdfs"
-    exclude group: "org.apache.hadoop", module: "hadoop-mapreduce-client-core"
-    exclude group: "org.apache.hbase", module: "hbase-client"
-    exclude group: "org.datanucleus", module: "datanucleus-api-jdo"
-    exclude group: "org.datanucleus", module: "datanucleus-core"
-    exclude group: "org.datanucleus", module: "datanucleus-rdbms"
-  }
   compile "org.apache.flink:flink-streaming-java_2.11:$flink_version"
   testCompile project(path: ":sdks:java:core", configuration: "shadowTest")
   // FlinkStateInternalsTest extends abstract StateInternalsTest
@@ -201,6 +182,25 @@ dependencies {
       compile("com.lyft:streamingplatform-kafka:2.1-SNAPSHOT") {
         exclude group: "org.apache.flink", module: "flink-connector-kafka-0.11_2.11"
         exclude group: "org.apache.flink", module: "flink-streaming-java_2.11"
+      }
+      compile("com.lyft:streamingplatform-events-source:2.1-dryft-SNAPSHOT") {
+        exclude group: "com.lyft", module: "streamingplatform-kinesis"
+        exclude group: "com.google.guava", module: "guava"
+        exclude group: "com.google.protobuf", module: "protobuf-java"
+        exclude group: "co.cask.tephra", module: "tephra-api"
+        exclude group: "co.cask.tephra", module: "tephra-core"
+        exclude group: "co.cask.tephra", module: "tephra-hbase-compat-1.0"
+        exclude group: "com.jolbox", module: "bonecp"
+        exclude group: "com.zaxxer", module: "HikariCP"
+        exclude group: "javolution", module: "javolution"
+        exclude group: "org.antlr", module: "antlr-runtime"
+        exclude group: "org.apache.hadoop", module: "hadoop-common"
+        exclude group: "org.apache.hadoop", module: "hadoop-hdfs"
+        exclude group: "org.apache.hadoop", module: "hadoop-mapreduce-client-core"
+        exclude group: "org.apache.hbase", module: "hbase-client"
+        exclude group: "org.datanucleus", module: "datanucleus-api-jdo"
+        exclude group: "org.datanucleus", module: "datanucleus-core"
+        exclude group: "org.datanucleus", module: "datanucleus-rdbms"
       }
   } else {
       compile "org.apache.flink:flink-connector-kafka-0.11_2.11:1.8-lyft20190924"

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -22,22 +22,32 @@ import static com.lyft.streamingplatform.analytics.EventUtils.DB_DATETIME_FORMAT
 import static com.lyft.streamingplatform.analytics.EventUtils.GMT;
 import static com.lyft.streamingplatform.analytics.EventUtils.ISO_DATETIME_FORMATTER;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import com.lyft.streamingplatform.LyftKafkaConsumerBuilder;
 import com.lyft.streamingplatform.LyftKafkaProducerBuilder;
+import com.lyft.streamingplatform.analytics.Event;
 import com.lyft.streamingplatform.analytics.EventField;
+import com.lyft.streamingplatform.eventssource.KinesisAndS3EventSource;
+import com.lyft.streamingplatform.eventssource.config.EventConfig;
+import com.lyft.streamingplatform.eventssource.config.KinesisConfig;
+import com.lyft.streamingplatform.eventssource.config.S3Config;
+import com.lyft.streamingplatform.eventssource.config.SourceContext;
 import com.lyft.streamingplatform.flink.FlinkLyftKinesisConsumer;
 import com.lyft.streamingplatform.flink.InitialRoundRobinKinesisShardAssigner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.zip.DataFormatException;
@@ -54,10 +64,13 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -84,6 +97,7 @@ public class LyftFlinkStreamingPortableTranslations {
   private static final String FLINK_KAFKA_URN = "lyft:flinkKafkaInput";
   private static final String FLINK_KAFKA_SINK_URN = "lyft:flinkKafkaSink";
   private static final String FLINK_KINESIS_URN = "lyft:flinkKinesisInput";
+  private static final String FLINK_S3_AND_KINESIS_URN = "lyft:flinkS3AndKinesisInput";
   private static final String BYTES_ENCODING = "bytes";
   private static final String LYFT_BASE64_ZLIB_JSON = "lyft-base64-zlib-json";
 
@@ -93,7 +107,9 @@ public class LyftFlinkStreamingPortableTranslations {
     public boolean test(RunnerApi.PTransform pTransform) {
       return FLINK_KAFKA_URN.equals(PTransformTranslation.urnForTransformOrNull(pTransform))
           || FLINK_KAFKA_SINK_URN.equals(PTransformTranslation.urnForTransformOrNull(pTransform))
-          || FLINK_KINESIS_URN.equals(PTransformTranslation.urnForTransformOrNull(pTransform));
+          || FLINK_KINESIS_URN.equals(PTransformTranslation.urnForTransformOrNull(pTransform))
+          || FLINK_S3_AND_KINESIS_URN.equals(
+              PTransformTranslation.urnForTransformOrNull(pTransform));
     }
   }
 
@@ -103,6 +119,7 @@ public class LyftFlinkStreamingPortableTranslations {
     translatorMap.put(FLINK_KAFKA_URN, this::translateKafkaInput);
     translatorMap.put(FLINK_KAFKA_SINK_URN, this::translateKafkaSink);
     translatorMap.put(FLINK_KINESIS_URN, this::translateKinesisInput);
+    translatorMap.put(FLINK_S3_AND_KINESIS_URN, this::translateS3AndKinesisInputs);
   }
 
   @VisibleForTesting
@@ -355,6 +372,221 @@ public class LyftFlinkStreamingPortableTranslations {
         context
             .getExecutionEnvironment()
             .addSource(source, FlinkLyftKinesisConsumer.class.getSimpleName()));
+  }
+
+  private void translateS3AndKinesisInputs(
+      String id,
+      RunnerApi.Pipeline pipeline,
+      FlinkStreamingPortablePipelineTranslator.StreamingTranslationContext context) {
+    RunnerApi.PTransform pTransform = pipeline.getComponents().getTransformsOrThrow(id);
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    try {
+      JsonNode params = mapper.readTree(pTransform.getSpec().getPayload().toByteArray());
+      Map<?, ?> jsonMap = mapper.convertValue(params, Map.class);
+      String sourceName = (String) jsonMap.get("source_name");
+      Preconditions.checkNotNull(sourceName, "Source name has to be set");
+      Map<String, JsonNode> userKinesisConfig =
+          mapper.convertValue(
+              jsonMap.get("kinesis"), new TypeReference<Map<String, JsonNode>>() {});
+
+      Map<String, JsonNode> userS3Config =
+          mapper.convertValue(jsonMap.get("s3"), new TypeReference<Map<String, JsonNode>>() {});
+
+      List<Map<String, JsonNode>> events =
+          mapper.convertValue(
+              jsonMap.get("events"), new TypeReference<List<Map<String, JsonNode>>>() {});
+
+      KinesisConfig kinesisConfig = getKinesisConfig(userKinesisConfig, mapper);
+      S3Config s3Config = getS3Config(userS3Config);
+      List<EventConfig> eventConfigs = getEventConfigs(events);
+
+      SourceContext sourceContext =
+          new SourceContext.Builder()
+              .withStreamConfig(kinesisConfig)
+              .withS3Config(s3Config)
+              .withEventConfigs(eventConfigs)
+              .withSourceName(sourceName)
+              .build();
+
+      KinesisAndS3EventSource source = new KinesisAndS3EventSource();
+      StreamExecutionEnvironment environment = context.getExecutionEnvironment();
+      Map<String, DataStream<Event>> eventStreams =
+          source.getEventStreams(environment, sourceContext);
+
+      LOG.info("Unioning all the event streams");
+      DataStream<Event> unionedStream = eventStreams.remove(eventConfigs.get(0).eventName);
+      for (Map.Entry<String, DataStream<Event>> entry : eventStreams.entrySet()) {
+        unionedStream = unionedStream.union(entry.getValue());
+      }
+
+      DataStream<WindowedValue<byte[]>> windowedStream =
+          unionedStream
+              .map(new EventToWindowedValue())
+              .name("windowed_value_stream")
+              .uid("windowed_value_stream");
+
+      context.addDataStream(
+          Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
+          windowedStream.rebalance());
+
+    } catch (IOException e) {
+      throw new RuntimeException("Could not parse provided source json");
+    }
+  }
+
+  @VisibleForTesting
+  List<EventConfig> getEventConfigs(List<Map<String, JsonNode>> events) {
+    List<EventConfig> eventConfigs = Lists.newArrayList();
+    for (Map<String, JsonNode> node : events) {
+      Preconditions.checkNotNull(node.get("name"), "Event name has to be set");
+      EventConfig.Builder builder = new EventConfig.Builder(node.get("name").asText());
+
+      // Add lateness in sec
+      JsonNode latenessInSec = node.get("lateness_in_sec");
+      if (latenessInSec != null) {
+        builder = builder.withLatenessInSec(latenessInSec.asLong());
+      }
+
+      // Add lookback hours
+      JsonNode lookbackDays = node.get("lookback_days");
+      if (lookbackDays != null) {
+        builder = builder.withLookbackInDays(lookbackDays.asInt());
+      }
+
+      eventConfigs.add(builder.build());
+    }
+
+    return eventConfigs;
+  }
+
+  @VisibleForTesting
+  S3Config getS3Config(Map<String, JsonNode> userS3Config) {
+    S3Config.Builder builder = new S3Config.Builder();
+
+    // Add s3 parallelism
+    JsonNode parallelism = userS3Config.get("parallelism");
+    if (parallelism != null) {
+      builder = builder.withParallelism(parallelism.asInt());
+    }
+
+    // Add s3 lookback hours
+    JsonNode lookbackHours = userS3Config.get("lookback_hours");
+    if (lookbackHours != null) {
+      builder = builder.withLookbackHours(lookbackHours.asInt());
+    }
+
+    return builder.build();
+  }
+
+  @VisibleForTesting
+  KinesisConfig getKinesisConfig(Map<String, JsonNode> userKinesisConfig, ObjectMapper mapper) {
+    Properties properties = new Properties();
+    Preconditions.checkNotNull(
+        userKinesisConfig.get("stream"), "Kinesis stream name needs to be set");
+
+    KinesisConfig.Builder builder =
+        new KinesisConfig.Builder(userKinesisConfig.get("stream").asText());
+    // Add kinesis parallelism
+    JsonNode kinesisParallelism = userKinesisConfig.get("parallelism");
+    if (kinesisParallelism != null) {
+      builder = builder.withParallelism(kinesisParallelism.asInt());
+    }
+    // Add kinesis properties
+    Map<String, String> kinesisProps =
+        mapper.convertValue(
+            userKinesisConfig.get("properties"), new TypeReference<Map<String, String>>() {});
+    if (kinesisProps != null) {
+      for (Map.Entry<String, String> property : kinesisProps.entrySet()) {
+        properties.put(property.getKey(), property.getValue());
+      }
+      builder = builder.withProperties(properties);
+    }
+    // Add kinesis stream start mode
+    JsonNode streamStartMode = userKinesisConfig.get("stream_start_mode");
+    if (streamStartMode != null) {
+      builder = builder.withStreamStartMode(streamStartMode.asText());
+    }
+
+    return builder.build();
+  }
+
+  @VisibleForTesting
+  static class EventToWindowedValue implements MapFunction<Event, WindowedValue<byte[]>> {
+
+    @Override
+    public WindowedValue<byte[]> map(Event value) {
+      return WindowedValue.timestampedValueInGlobalWindow(
+          getBytes(value), new Instant(getTimestamp(value)));
+    }
+
+    long getTimestamp(Event event) {
+      Object occurredAt = event.get(EventField.EventOccurredAt.fieldName());
+      long occurredAtMs = 0L;
+      try {
+        if (occurredAt instanceof String) {
+          occurredAtMs = parseDateTime((String) occurredAt);
+        } else if (occurredAt instanceof Long || occurredAt instanceof Integer) {
+          occurredAtMs = (long) occurredAt;
+        } else if (occurredAt instanceof Timestamp) {
+          occurredAtMs = ((Timestamp) occurredAt).getTime();
+        } else {
+          LOG.warn("Occurred at ts unrecognized");
+        }
+        if (event.contains(EventField.EventLoggedAt.fieldName())) {
+          Object loggedAt = event.get(EventField.EventLoggedAt.fieldName());
+          long loggedAtMs = 0L;
+          if (loggedAt instanceof String) {
+            loggedAtMs = Long.parseLong(event.get(EventField.EventLoggedAt.fieldName()));
+          } else if (loggedAt instanceof Long || loggedAt instanceof Integer) {
+            loggedAtMs = (long) loggedAt;
+          } else if (loggedAt instanceof Timestamp) {
+            loggedAtMs = ((Timestamp) loggedAt).getTime();
+          } else {
+            LOG.warn("Logged at ts unrecognized");
+          }
+          if (loggedAtMs > 0 && loggedAtMs < Integer.MAX_VALUE) {
+            loggedAtMs *= 1000;
+          }
+          if (loggedAtMs != 0) {
+            occurredAtMs = Math.min(occurredAtMs, loggedAtMs);
+          }
+        }
+      } catch (DateTimeParseException | NumberFormatException e) {
+        // skip this event
+        LOG.warn("Skipping event: " + event.get(EventField.EventName.fieldName()));
+      }
+      return occurredAtMs;
+    }
+
+    // TODO: https://jira.lyft.net/browse/STRMCMP-1109
+    private static long parseDateTime(String datetime) {
+      try {
+        DateTimeFormatter formatterToUse =
+            (datetime.length() - datetime.indexOf('.') == 7)
+                ? DB_DATETIME_FORMATTER
+                : BACKUP_DB_DATETIME_FORMATTER;
+        TemporalAccessor temporalAccessor = formatterToUse.parse(datetime);
+        LocalDateTime localDateTime = LocalDateTime.from(temporalAccessor);
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, GMT);
+        return java.time.Instant.from(zonedDateTime).toEpochMilli();
+      } catch (DateTimeParseException e) {
+        return java.time.Instant.from(ISO_DATETIME_FORMATTER.parse(datetime)).toEpochMilli();
+      }
+    }
+
+    private byte[] getBytes(Event event) {
+      ObjectMapper mapper = new ObjectMapper();
+      try {
+        return mapper.writeValueAsBytes(event);
+      } catch (JsonProcessingException e) {
+        LOG.warn(
+            "Unable to convert event json to byte[]: "
+                + event.get(EventField.EventName.fieldName()));
+      }
+      return new byte[0];
+    }
   }
 
   /**

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -24,12 +25,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lyft.streamingplatform.analytics.Event;
+import com.lyft.streamingplatform.analytics.EventField;
+import com.lyft.streamingplatform.eventssource.config.EventConfig;
+import com.lyft.streamingplatform.eventssource.config.KinesisConfig;
+import com.lyft.streamingplatform.eventssource.config.S3Config;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
+import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.zip.Deflater;
@@ -38,6 +52,8 @@ import org.apache.beam.runners.flink.LyftFlinkStreamingPortableTranslations.Lyft
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Resources;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -326,5 +342,107 @@ public class LyftFlinkStreamingPortableTranslationsTest {
             .build();
 
     return pipeline;
+  }
+
+  @Test
+  public void testGetTimestampFromEvent() {
+    LyftFlinkStreamingPortableTranslations.EventToWindowedValue mapFn =
+        new LyftFlinkStreamingPortableTranslations.EventToWindowedValue();
+
+    Map<String, Serializable> eventFields = Maps.newHashMap();
+    eventFields.put(EventField.EventOccurredAt.fieldName(), "2020-05-05 12:00:00");
+    Event event = new Event(eventFields);
+
+    // Verify if time is String
+    assertEquals(1588680000000L, mapFn.getTimestamp(event));
+
+    eventFields.put(EventField.EventOccurredAt.fieldName(), 1588680000L);
+    event.setFields(eventFields);
+    // Verify if time is Long
+    assertEquals(1588680000L, mapFn.getTimestamp(event));
+
+    Timestamp timestamp = new Timestamp(1588680000L);
+    eventFields.put(EventField.EventOccurredAt.fieldName(), timestamp);
+    event.setFields(eventFields);
+    // Verify if time is Timestamp
+    assertEquals(1588680000L, mapFn.getTimestamp(event));
+
+    eventFields.put(EventField.EventOccurredAt.fieldName(), 3.214F);
+    event.setFields(eventFields);
+    // Verify handling of unrecognized type of occurredAt time
+    assertEquals(0L, mapFn.getTimestamp(event));
+
+    eventFields.put(EventField.EventOccurredAt.fieldName(), "2020-05-05 12:00:00");
+    eventFields.put(EventField.EventLoggedAt.fieldName(), "1588593600");
+    event.setFields(eventFields);
+
+    // Verifies function returns min of occurredAt and loggedAt
+    assertEquals(1588593600000L, mapFn.getTimestamp(event));
+
+    eventFields.put(EventField.EventLoggedAt.fieldName(), 1588593600L);
+    event.setFields(eventFields);
+    assertEquals(1588593600000L, mapFn.getTimestamp(event));
+
+    eventFields.put(EventField.EventLoggedAt.fieldName(), new Timestamp(1588593600L));
+    event.setFields(eventFields);
+    assertEquals(1588593600000L, mapFn.getTimestamp(event));
+  }
+
+  @Test
+  public void testGetEventConfigs() throws IOException {
+    LyftFlinkStreamingPortableTranslations translations =
+        new LyftFlinkStreamingPortableTranslations();
+    ObjectMapper mapper = new ObjectMapper();
+    Map<?, ?> jsonMap = getJsonMap(mapper);
+    List<Map<String, JsonNode>> events =
+        mapper.convertValue(
+            jsonMap.get("events"), new TypeReference<List<Map<String, JsonNode>>>() {});
+
+    List<EventConfig> eventConfigs = translations.getEventConfigs(events);
+
+    assertEquals(1, eventConfigs.size());
+    EventConfig event = eventConfigs.get(0);
+    assertEquals("test_event", event.eventName);
+    assertEquals(5, event.latenessInSeconds);
+    assertEquals(1, event.lookbackInDays);
+  }
+
+  @Test
+  public void testGetKinesisConfig() throws IOException {
+    LyftFlinkStreamingPortableTranslations translations =
+        new LyftFlinkStreamingPortableTranslations();
+    ObjectMapper mapper = new ObjectMapper();
+    Map<?, ?> jsonMap = getJsonMap(mapper);
+    Map<String, JsonNode> userKinesisConfig =
+        mapper.convertValue(jsonMap.get("kinesis"), new TypeReference<Map<String, JsonNode>>() {});
+
+    KinesisConfig kinesisConfig = translations.getKinesisConfig(userKinesisConfig, mapper);
+
+    assertEquals("kinesis_stream", kinesisConfig.getStreamName());
+    assertEquals(1, kinesisConfig.getParallelism());
+    assertEquals("LATEST", kinesisConfig.getStreamStartMode());
+    assertEquals("us-west-2", kinesisConfig.getProperties().getProperty("aws.region"));
+  }
+
+  @Test
+  public void testGetS3Config() throws IOException {
+    LyftFlinkStreamingPortableTranslations translations =
+        new LyftFlinkStreamingPortableTranslations();
+    ObjectMapper mapper = new ObjectMapper();
+    Map<?, ?> jsonMap = getJsonMap(mapper);
+    Map<String, JsonNode> userS3Config =
+        mapper.convertValue(jsonMap.get("s3"), new TypeReference<Map<String, JsonNode>>() {});
+
+    S3Config s3Config = translations.getS3Config(userS3Config);
+    assertEquals(1, s3Config.parallelism);
+    assertEquals(12, s3Config.lookbackHours);
+  }
+
+  private Map<?, ?> getJsonMap(ObjectMapper mapper) throws IOException {
+    URL url =
+        LyftFlinkStreamingPortableTranslationsTest.class.getResource("/s3_and_kinesis_config.json");
+    String eventsStr = Resources.toString(url, StandardCharsets.UTF_8);
+    JsonNode jsonNode = mapper.readTree(eventsStr);
+    return mapper.convertValue(jsonNode, Map.class);
   }
 }

--- a/runners/flink/src/test/resources/s3_and_kinesis_config.json
+++ b/runners/flink/src/test/resources/s3_and_kinesis_config.json
@@ -1,0 +1,21 @@
+{
+  "events": [
+    {
+      "name": "test_event",
+      "lateness_in_sec": 5,
+      "lookback_days": 1
+    }
+  ],
+  "s3": {
+    "parallelism": 1,
+    "lookback_hours": 12
+  },
+  "kinesis": {
+    "stream": "kinesis_stream",
+    "parallelism": 1,
+    "properties": {
+      "aws.region": "us-west-2"
+    },
+    "stream_start_mode": "LATEST"
+  }
+}

--- a/sdks/python/apache_beam/io/lyft/s3_and_kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/s3_and_kinesis.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import random
+import string
+from collections import namedtuple
+
+from apache_beam import PTransform
+from apache_beam.pvalue import PBegin
+from apache_beam.pvalue import PCollection
+from apache_beam.transforms.core import Windowing
+from apache_beam.transforms.window import GlobalWindows
+
+Event = namedtuple('Event', 'name lateness_in_sec lookback_days')
+S3Config = namedtuple('S3Config', 'parallelism lookback_hours')
+
+
+class S3AndKinesisInput(PTransform):
+    """Custom composite transform that uses Kinesis and S3 as
+    input sources. This wraps the streamingplatform-dryft-sdk SourceConnector.
+    Only works with the portable Flink runner.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.events = []
+        self.s3_config = S3Config(None, None)
+        self.source_name = 'S3andKinesis_' + self._get_random_source_name()
+        self.kinesis_properties = {'aws.region': 'us-east-1'}
+        self.stream_start_mode = 'TRIM_HORIZON'
+        self.kinesis_parallelism = 1
+
+    def expand(self, pbegin):
+        assert isinstance(pbegin, PBegin), (
+                'Input to transform must be a PBegin but found %s' % pbegin)
+        return PCollection(pbegin.pipeline)
+
+    def get_windowing(self, inputs):
+        return Windowing(GlobalWindows())
+
+    def infer_output_type(self, unused_input_type):
+        return bytes
+
+    def with_event(self, event):
+        self.events.append(event)
+        return self
+
+    def with_kinesis_stream_name(self, stream_name):
+        self.stream_name = stream_name
+        return self
+
+    # Defaults to 1
+    def with_kinesis_parallelism(self, parallelism):
+        self.kinesis_parallelism = parallelism
+        return self
+
+    # Defaults to TRIM_HORIZON
+    def with_kinesis_stream_start_mode(self, stream_start_mode):
+        self.stream_start_mode = stream_start_mode
+        return self
+
+    def with_kinesis_property(self, key, value):
+        self.kinesis_properties[key] = value
+        return self
+
+    def with_s3_config(self, s3_config):
+        self.s3_config = s3_config
+        return self
+
+    def with_source_name(self, source_name):
+        self.source_name = source_name
+        return self
+
+    def with_kinesis_endpoint(self, endpoint, access_key, secret_key):
+        self.kinesis_properties.pop('aws.region', None)
+        self.kinesis_properties['aws.endpoint'] = endpoint
+        self.kinesis_properties['aws.credentials.provider.basic.accesskeyid'] = access_key
+        self.kinesis_properties['aws.credentials.provider.basic.secretkey'] = secret_key
+        return self
+
+    @staticmethod
+    @PTransform.register_urn("lyft:flinkS3AndKinesisInput", None)
+    def from_runner_api_parameter(_unused_ptransform, spec_parameter, _unused_context):
+        logging.info("S3AndKinesisInput spec: %s", spec_parameter)
+        instance = S3AndKinesisInput()
+        payload = json.loads(spec_parameter)
+        instance.source_name = payload['source_name']
+        s3_config_dict = payload['s3']
+        instance.s3_config = S3Config(
+            parallelism=s3_config_dict.get('parallelism', None),
+            lookback_hours=s3_config_dict.get('lookback_hours', None)
+        )
+        kinesis_config_dict = payload['kinesis']
+        instance.stream_name = kinesis_config_dict.get('stream')
+        instance.kinesis_properties = kinesis_config_dict.get('properties', None)
+        instance.kinesis_parallelism = kinesis_config_dict.get('parallelism', None)
+        instance.stream_start_mode = kinesis_config_dict.get('stream_start_mode', None)
+        events_list = payload['events']
+        instance.events = []
+        for event in events_list:
+            assert event.get('name') is not None, "Event name must be set"
+            instance.events.append(
+                Event(
+                    name=event.get('name'),
+                    lateness_in_sec=event.get('lateness_in_sec', None),
+                    lookback_days=event.get('lookback_days', None)
+                )
+            )
+        return instance
+
+    def to_runner_api_parameter(self, _unused_context):
+        assert isinstance(self, S3AndKinesisInput), \
+            "expected instance of S3AndKinesisInput, but got %s" % self.__class__
+        assert self.stream_name is not None, "Kinesis stream name not set"
+
+        json_map = {
+            'source_name': self.source_name,
+            'kinesis': {
+                'stream': self.stream_name,
+                'properties': self.kinesis_properties,
+                'parallelism': self.kinesis_parallelism,
+                'stream_start_mode': self.stream_start_mode
+            },
+            's3': {
+                'parallelism': self.s3_config.parallelism,
+                'lookback_hours': self.s3_config.lookback_hours
+            },
+        }
+
+        event_list_json = []
+        for e in self.events:
+            assert isinstance(e, Event), "expected instance of Event, but got %s" % type(e)
+            event_map = {'name': e.name, 'lateness_in_sec': e.lateness_in_sec, 'lookback_days': e.lookback_days}
+            event_list_json.append(event_map)
+
+        json_map['events'] = event_list_json
+
+        return "lyft:flinkS3AndKinesisInput", json.dumps(json_map, default=self._set_to_list_conversion)
+
+    def _set_to_list_conversion(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+        return obj
+
+    def _get_random_source_name(self):
+        letters = string.ascii_lowercase
+        return ''.join(random.choice(letters) for _ in range(4))


### PR DESCRIPTION
Adding new translations for the S3 and kinesis source.
Also adding the composite transform that can be used to construct the S3 and Kinesis source.

The size of the jar is now around 260MB.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

