### PR TITLE
[LYFT][STRMCMP-1155] S3 event parsing failures

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -589,7 +589,7 @@ public class LyftFlinkStreamingPortableTranslations {
     private byte[] getBytes(Event event) {
       ObjectMapper mapper = new ObjectMapper();
       try {
-        return mapper.writeValueAsBytes(event);
+        return mapper.writeValueAsBytes(event.getAll());
       } catch (JsonProcessingException e) {
         LOG.warn(
             "Unable to convert event json to byte[]: "


### PR DESCRIPTION
The PR fixes the bug in the Event serialization which was leading to job failures as the JSON serialized analytic event data had a different structure.  

Instead of `{k, v}` , the pipeline received the event data as `{'all' : {k, v}}` downstream to `s3AndKinesis` source.  

Verified:
http://beamperfk8s2.ingress.semistateful-prod-0.us-east-1.k8s.lyft.net/#/job/9119b65628928351c114f944f6549131/overview/b5641b2f547b82cd56bf1f51a4a4d19e/detail