### PR TITLE
[LYFT] [STRMCMP-1182] config for lyft repo mappings

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/Repositories.groovy
@@ -22,6 +22,13 @@ import org.gradle.api.Project
 
 class Repositories {
 
+  static class Repository {
+    String url
+    String id
+    String username
+    String password
+  }
+
   static void register(Project project) {
 
     project.repositories {
@@ -62,54 +69,80 @@ class Repositories {
       }
 
       //LYFT CUSTOM pull in the central repo override from settings, if any
-      def settingsXml = new File(System.getProperty('user.home'), '.m2/settings.xml')
-      if (settingsXml.exists()) {
-        def serverId = "lyft-releases"
-        def repo = new XmlSlurper().parse(settingsXml).'**'.find { n -> n.name() == 'repository' && serverId.equals(n.id.text()) }
-        if (repo) {
-          def GroovyShell shell = new GroovyShell(new Binding([env:System.getenv()]))
-          maven {
-            url shell.evaluate('"' + repo.url.text() +'"')
-            name repo.id.text()
-            def m2SettingCreds = new XmlSlurper().parse(settingsXml).servers.server.find { server -> serverId.equals(server.id.text()) }
-            if (m2SettingCreds) {
-              credentials {
-                username shell.evaluate('"' + m2SettingCreds.username.text() + '"')
-                password shell.evaluate('"' + m2SettingCreds.password.text() + '"')
-              }
-            }
+      Repository releasesConfig = fetchLyftRepositoryConfig("lyft-releases")
+      if (releasesConfig.url != null) {
+        maven {
+          url releasesConfig.url
+          name releasesConfig.id
+          credentials {
+            username releasesConfig.username
+            password releasesConfig.password
           }
         }
       }
 
-    }
-
-    // plugin to support repository authentication via ~/.m2/settings.xml
-    // https://github.com/mark-vieira/gradle-maven-settings-plugin/
-    project.apply plugin: 'net.linguica.maven-settings'
-
-    // Apply a plugin which provides the 'updateOfflineRepository' task that creates an offline
-    // repository. This offline repository satisfies all Gradle build dependencies and Java
-    // project dependencies. The offline repository is placed within $rootDir/offline-repo
-    // but can be overridden by specifying '-PofflineRepositoryRoot=/path/to/repo'.
-    // Note that parallel build must be disabled when executing 'updateOfflineRepository'
-    // by specifying '--no-parallel', see
-    // https://github.com/mdietrichstein/gradle-offline-dependencies-plugin/issues/3
-    project.apply plugin: "io.pry.gradle.offline_dependencies"
-    project.offlineDependencies {
-      repositories {
-        mavenLocal()
-        mavenCentral()
-        jcenter()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://repo.spring.io/plugins-release" }
-        maven { url "https://packages.confluent.io/maven/" }
-        maven { url project.offlineRepositoryRoot }
+      Repository snapshotsConfig = fetchLyftRepositoryConfig("lyft-snapshots")
+      if (snapshotsConfig.url != null) {
+        maven {
+          url snapshotsConfig.url
+          name snapshotsConfig.id
+          credentials {
+            username snapshotsConfig.username
+            password snapshotsConfig.password
+          }
+        }
       }
-      includeSources = false
-      includeJavadocs = false
-      includeIvyXmls = false
+
+      // plugin to support repository authentication via ~/.m2/settings.xml
+      // https://github.com/mark-vieira/gradle-maven-settings-plugin/
+      project.apply plugin: 'net.linguica.maven-settings'
+
+      // Apply a plugin which provides the 'updateOfflineRepository' task that creates an offline
+      // repository. This offline repository satisfies all Gradle build dependencies and Java
+      // project dependencies. The offline repository is placed within $rootDir/offline-repo
+      // but can be overridden by specifying '-PofflineRepositoryRoot=/path/to/repo'.
+      // Note that parallel build must be disabled when executing 'updateOfflineRepository'
+      // by specifying '--no-parallel', see
+      // https://github.com/mdietrichstein/gradle-offline-dependencies-plugin/issues/3
+      project.apply plugin: "io.pry.gradle.offline_dependencies"
+      project.offlineDependencies {
+        repositories {
+          mavenLocal()
+          mavenCentral()
+          jcenter()
+          maven { url "https://plugins.gradle.org/m2/" }
+          maven { url "https://repo.spring.io/plugins-release" }
+          maven { url "https://packages.confluent.io/maven/" }
+          maven { url project.offlineRepositoryRoot }
+        }
+        includeSources = false
+        includeJavadocs = false
+        includeIvyXmls = false
+      }
     }
+  }
+
+  /**
+   * parses the settings.xml in the home directory for repository configuration
+   * @param serverId : id given to repository in the settings.xml
+   * @return
+   */
+  static Repository fetchLyftRepositoryConfig(String serverId) {
+    def settingsXml = new File(System.getProperty('user.home'), '.m2/settings.xml')
+    def content = new XmlSlurper().parse(settingsXml)
+    def repo = content.'**'.find { n -> n.name() == 'repository' && serverId.equals(n.id.text()) }
+    Repositories.Repository repository = new Repositories.Repository()
+    if (repo) {
+      GroovyShell shell = new GroovyShell(new Binding([env: System.getenv()]))
+      repository.url = shell.evaluate('"' + repo.url.text() + '"')
+      repository.id = repo.id.text()
+      def m2SettingCreds = content.servers.server.find { server -> serverId.equals(server.id.text()) }
+      if (m2SettingCreds) {
+        repository.username = shell.evaluate('"' + m2SettingCreds.username.text() + '"')
+        repository.password = shell.evaluate('"' + m2SettingCreds.password.text() + '"')
+      }
+    }
+    return repository
   }
 }
 


### PR DESCRIPTION
Recent changes in [jarjarflinks](https://groups.google.com/a/lyft.com/g/data-platform/c/vWPMb9NI2Zc/m/ZwBNTzPDBwAJ)  w.r.t virtual repo mapping for lib-releases has affected Beam builds as we have few of our streamingplatform-* artifacts available within lib-snapshots and they aren't resolvable.

