### PR TITLE
[LYFT][STRMCMP-1472] Cython deps as prereq

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -131,6 +131,7 @@ REQUIRED_PACKAGES = [
     # Avro 1.9.2 for python3 was broken. The issue was fixed in version 1.9.2.1
     'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
     'crcmod>=1.7,<2.0',
+    'cython==' + REQUIRED_CYTHON_VERSION,
     # dataclasses backport for python_version<3.7. No version bound because this
     # is Python standard since Python 3.7 and each Python version is compatible
     # with a specific dataclasses version.


### PR DESCRIPTION
- Ensures cython is installed as a dependency.
- Given we release wheels for linux only, installations on mac forces a tar.gz download followed by the install. Without this commit, due to lack of `cython` dependency, the necessary `so` files  were not created. 