### PR TITLE
[LYFT] [STRMCMP-1594] Have min python v at 3.8

### DIFF
--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -72,4 +72,4 @@ split_before_logical_operator = False
 i18n_comment = # type: ignore.*
 
 [options]
-python_requires= >=3.6
+python_requires= >=3.8


### PR DESCRIPTION
1. With all Streaming jobs on python 3.8, making this change to enforce our infra releases source dist along with wheels. 
