### PR TITLE
[RTOP-2169] Adding support for kinesis consumer synchronization

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -87,6 +87,7 @@ import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.util.JobManagerWatermarkTracker;
+import org.apache.flink.streaming.connectors.kinesis.util.WatermarkTracker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
@@ -388,6 +389,9 @@ public class LyftFlinkStreamingPortableTranslations {
           throw new IllegalArgumentException("Unknown encoding '" + encoding + "'");
       }
 
+      if (params.hasNonNull("use_global_watermark_tracker") && params.get("use_global_watermark_tracker").asBoolean()) {
+        source.setWatermarkTracker(GLOBAL_WATERMARK);
+      }
       LOG.info(
           "Kinesis consumer for stream {} with properties {} and encoding {}",
           stream,
@@ -401,9 +405,6 @@ public class LyftFlinkStreamingPortableTranslations {
     source.setShardAssigner(
         InitialRoundRobinKinesisShardAssigner.fromInitialShards(
             properties, stream, context.getExecutionEnvironment().getConfig().getParallelism()));
-    if (params.hasNonNull("use_global_watermark_tracker") && params.get("use_global_watermark_tracker").asBoolean()) {
-      source.setWatermarkTracker(GLOBAL_WATERMARK);
-    }
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
         context

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -401,7 +401,7 @@ public class LyftFlinkStreamingPortableTranslations {
     source.setShardAssigner(
         InitialRoundRobinKinesisShardAssigner.fromInitialShards(
             properties, stream, context.getExecutionEnvironment().getConfig().getParallelism()));
-    if (params.hasNonNull("use_watermark_tracker")) {
+    if (params.hasNonNull("use_watermark_tracker") && params.get("use_watermark_tracker").asBoolean()) {
       source.setWatermarkTracker(GLOBAL_WATERMARK);
     }
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -401,7 +401,7 @@ public class LyftFlinkStreamingPortableTranslations {
     source.setShardAssigner(
         InitialRoundRobinKinesisShardAssigner.fromInitialShards(
             properties, stream, context.getExecutionEnvironment().getConfig().getParallelism()));
-    if (params.hasNonNull("use_watermark_tracker") && params.get("use_watermark_tracker").asBoolean()) {
+    if (params.hasNonNull("use_global_watermark_tracker") && params.get("use_global_watermark_tracker").asBoolean()) {
       source.setWatermarkTracker(GLOBAL_WATERMARK);
     }
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -86,6 +86,7 @@ import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
+import org.apache.flink.streaming.connectors.kinesis.util.JobManagerWatermarkTracker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
@@ -106,6 +107,8 @@ public class LyftFlinkStreamingPortableTranslations {
   private static final String FLINK_S3_URN = "lyft:flinkS3Input";
   private static final String BYTES_ENCODING = "bytes";
   private static final String LYFT_BASE64_ZLIB_JSON = "lyft-base64-zlib-json";
+
+  private static final WatermarkTracker GLOBAL_WATERMARK = new JobManagerWatermarkTracker("globalWatermark");
 
   @AutoService(NativeTransforms.IsNativeTransform.class)
   public static class IsFlinkNativeTransform implements NativeTransforms.IsNativeTransform {
@@ -398,6 +401,9 @@ public class LyftFlinkStreamingPortableTranslations {
     source.setShardAssigner(
         InitialRoundRobinKinesisShardAssigner.fromInitialShards(
             properties, stream, context.getExecutionEnvironment().getConfig().getParallelism()));
+    if (params.hasNonNull("use_watermark_tracker")) {
+      source.setWatermarkTracker(GLOBAL_WATERMARK);
+    }
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
         context

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -20,7 +20,7 @@ class FlinkKinesisInput(PTransform):
   stream = None
   encoding = None
   max_out_of_orderness_millis = None
-  use_watermark_tracker = None
+  use_global_watermark_tracker = None
 
   def expand(self, pbegin):
     assert isinstance(pbegin, pvalue.PBegin), (
@@ -44,7 +44,7 @@ class FlinkKinesisInput(PTransform):
       'encoding': self.encoding,
       'max_out_of_orderness_millis': self.max_out_of_orderness_millis,
       'properties': self.consumer_properties,
-      'use_watermark_tracker': self.use_watermark_tracker}))
+      'use_global_watermark_tracker': self.use_global_watermark_tracker}))
 
   @staticmethod
   @PTransform.register_urn("lyft:flinkKinesisInput", None)
@@ -56,7 +56,7 @@ class FlinkKinesisInput(PTransform):
     instance.encoding = payload['encoding']
     instance.max_out_of_orderness_millis = payload['max_out_of_orderness_millis']
     instance.consumer_properties = payload['properties']
-    instance.use_watermark_tracker = payload['use_watermark_tracker']
+    instance.use_global_watermark_tracker = payload['use_global_watermark_tracker']
     return instance
 
   def with_stream(self, stream):
@@ -95,10 +95,10 @@ class FlinkKinesisInput(PTransform):
     self.set_consumer_property('aws.credentials.provider.basic.secretkey', secret_key)
     return self
 
-  def with_watermark_tracker(self, use_watermark_tracker):
+  def with_global_watermark_tracker(self, use_global_watermark_tracker):
     """
     Enables consumer watermark synchronization. This can be enabled to reduce event time skew.
     https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/kinesis/#event-time-alignment-for-shard-consumers
     """
-    self.use_watermark_tracker = use_watermark_tracker
+    self.use_global_watermark_tracker = use_global_watermark_tracker
     return self

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -20,6 +20,7 @@ class FlinkKinesisInput(PTransform):
   stream = None
   encoding = None
   max_out_of_orderness_millis = None
+  use_watermark_tracker = None
 
   def expand(self, pbegin):
     assert isinstance(pbegin, pvalue.PBegin), (
@@ -42,7 +43,8 @@ class FlinkKinesisInput(PTransform):
       'stream': self.stream,
       'encoding': self.encoding,
       'max_out_of_orderness_millis': self.max_out_of_orderness_millis,
-      'properties': self.consumer_properties}))
+      'properties': self.consumer_properties,
+      'use_watermark_tracker': self.use_watermark_tracker}))
 
   @staticmethod
   @PTransform.register_urn("lyft:flinkKinesisInput", None)
@@ -54,6 +56,7 @@ class FlinkKinesisInput(PTransform):
     instance.encoding = payload['encoding']
     instance.max_out_of_orderness_millis = payload['max_out_of_orderness_millis']
     instance.consumer_properties = payload['properties']
+    instance.use_watermark_tracker = payload['use_watermark_tracker']
     return instance
 
   def with_stream(self, stream):
@@ -90,4 +93,12 @@ class FlinkKinesisInput(PTransform):
     self.set_consumer_property('aws.endpoint', endpoint)
     self.set_consumer_property('aws.credentials.provider.basic.accesskeyid', access_key)
     self.set_consumer_property('aws.credentials.provider.basic.secretkey', secret_key)
+    return self
+
+  def with_watermark_tracker(self, use_watermark_tracker):
+    """
+    Enables consumer watermark synchronization. This can be enabled to reduce event time skew.
+    https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/kinesis/#event-time-alignment-for-shard-consumers
+    """
+    self.use_watermark_tracker = use_watermark_tracker
     return self


### PR DESCRIPTION
Add [watermarker tracker support](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/connectors/datastream/kinesis/#event-time-alignment-for-shard-consumers) to `FlinkKinesisInput`.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/) | --- | --- | ---

