### PR TITLE
Update S3Input to align with S3AndKinesisInput

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -389,15 +389,15 @@ public class LyftFlinkStreamingPortableTranslations {
           throw new IllegalArgumentException("Unknown encoding '" + encoding + "'");
       }
 
-      if (params.hasNonNull("use_global_watermark_tracker") && params.get("use_global_watermark_tracker").asBoolean()) {
-        source.setWatermarkTracker(GLOBAL_WATERMARK);
-      }
       LOG.info(
           "Kinesis consumer for stream {} with properties {} and encoding {}",
           stream,
           properties,
           encoding);
-
+      if (params.hasNonNull("use_global_watermark_tracker") && params.get("use_global_watermark_tracker").asBoolean()) {
+        LOG.info("Using global watermark tracker on Kinesis consumer");
+        source.setWatermarkTracker(GLOBAL_WATERMARK);
+      }
     } catch (IOException e) {
       throw new RuntimeException("Could not parse Kinesis consumer properties.", e);
     }

--- a/sdks/python/apache_beam/io/lyft/kinesis.py
+++ b/sdks/python/apache_beam/io/lyft/kinesis.py
@@ -98,7 +98,7 @@ class FlinkKinesisInput(PTransform):
   def with_global_watermark_tracker(self, use_global_watermark_tracker):
     """
     Enables consumer watermark synchronization. This can be enabled to reduce event time skew.
-    https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/kinesis/#event-time-alignment-for-shard-consumers
+    https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/connectors/datastream/kinesis/#event-time-alignment-for-shard-consumers
     """
     self.use_global_watermark_tracker = use_global_watermark_tracker
     return self

--- a/sdks/python/apache_beam/io/lyft/s3.py
+++ b/sdks/python/apache_beam/io/lyft/s3.py
@@ -36,8 +36,8 @@ class S3Input(PTransform):
   def infer_output_type(self, unused_input_type):
     return bytes
 
-  def with_event_config(self, event):
-    self.events_config.append(event)
+  def with_event_config(self, event_config):
+    self.events_config.append(event_config)
     return self
 
   def with_s3_config(self, s3_config):


### PR DESCRIPTION
`S3Input` uses a parameter `lateness_in_sec`, but the Java translation code instead parses `max_out_of_orderness_millis` [[source](https://github.com/lyft/beam/blob/c027b7f1ffb411e544ed31ff62747a2170b41bf6/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java#L555)]. 

`S3AndKinesisInput` uses the correct parameter and has some other reusable classes (i.e., `EventConfig` and `S3Config`). This PR improves `S3Input` to be more aligned with `S3AndKinesisInput`.