### PR TITLE
Use KafkaSource instead of FlinkKafkaConsumer

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -550,7 +550,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def jaxb_api_version = "2.3.3"
     def jsr305_version = "3.0.2"
     def everit_json_version = "1.14.1"
-    def kafka_version = "2.4.1"
+    def kafka_version = "3.1.0"
     def log4j2_version = "2.20.0"
     def nemo_version = "0.1"
     // Try to keep netty_version consistent with the netty version in grpc_bom (includes grpc_netty) in google_cloud_platform_libraries_bom

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -550,7 +550,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def jaxb_api_version = "2.3.3"
     def jsr305_version = "3.0.2"
     def everit_json_version = "1.14.1"
-    def kafka_version = "3.1.0"
+    def kafka_version = "3.9.0"
     def log4j2_version = "2.20.0"
     def nemo_version = "0.1"
     // Try to keep netty_version consistent with the netty version in grpc_bom (includes grpc_netty) in google_cloud_platform_libraries_bom

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -218,7 +218,7 @@ dependencies {
   runtimeOnly project(":sdks:java:harness")
   implementation "com.amazonaws:aws-java-sdk-s3:1.10.6"
   implementation "org.apache.hadoop:hadoop-aws:2.8.5"
-  implementation ("com.lyft:streamingplatform-events-source:2.4.1-20240509.163625-9") {
+  implementation ("com.lyft:streamingplatform-events-source:2.6.0-SNAPSHOT") {
     exclude group: "com.lyft", module: "streamingplatform-kinesis"
     exclude group: "com.google.guava", module: "guava"
     exclude group: "com.google.protobuf", module: "protobuf-java"
@@ -239,8 +239,8 @@ dependencies {
     exclude group: "org.apache.logging.log4j", module: "log4j-core"
   }
   implementation "org.apache.flink:flink-connector-kafka:1.17-lyft202402051707167466"
-  implementation "com.lyft:streamingplatform-kinesis:2.4.1-20240509.163625-9"
-  implementation ("com.lyft:streamingplatform-kafka:2.4.1-20240509.163625-9") {
+  implementation "com.lyft:streamingplatform-kinesis:2.6.0-SNAPSHOT"
+  implementation ("com.lyft:streamingplatform-kafka:2.6.0-SNAPSHOT") {
     exclude group: "org.apache.flink", module: "flink-connector-kafka"
     exclude group: "org.apache.flink", module: "flink-streaming-java"
   }

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -218,7 +218,7 @@ dependencies {
   runtimeOnly project(":sdks:java:harness")
   implementation "com.amazonaws:aws-java-sdk-s3:1.10.6"
   implementation "org.apache.hadoop:hadoop-aws:2.8.5"
-  implementation ("com.lyft:streamingplatform-events-source:2.6.0-SNAPSHOT") {
+  implementation ("com.lyft:streamingplatform-events-source:2.6.2-SNAPSHOT") {
     exclude group: "com.lyft", module: "streamingplatform-kinesis"
     exclude group: "com.google.guava", module: "guava"
     exclude group: "com.google.protobuf", module: "protobuf-java"
@@ -239,8 +239,8 @@ dependencies {
     exclude group: "org.apache.logging.log4j", module: "log4j-core"
   }
   implementation "org.apache.flink:flink-connector-kafka:1.17-lyft202402051707167466"
-  implementation "com.lyft:streamingplatform-kinesis:2.6.0-SNAPSHOT"
-  implementation ("com.lyft:streamingplatform-kafka:2.6.0-SNAPSHOT") {
+  implementation "com.lyft:streamingplatform-kinesis:2.6.2-SNAPSHOT"
+  implementation ("com.lyft:streamingplatform-kafka:2.6.2-SNAPSHOT") {
     exclude group: "org.apache.flink", module: "flink-connector-kafka"
     exclude group: "org.apache.flink", module: "flink-streaming-java"
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -196,18 +196,11 @@ public class LyftFlinkStreamingPortableTranslations {
     }
 
     // Define the watermark strategy
-    WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy;
+    WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy =
+        WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
+            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
     if (idlenessTimeoutMillis != null) {
-      watermarkStrategy =
-          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-              Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
-          .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
-    } else {
-      watermarkStrategy =
-          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-              Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
-          .withTimestampAssigner((element, recordTimestamp) ->
-              element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+      watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -201,6 +201,12 @@ public class LyftFlinkStreamingPortableTranslations {
             Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
     if (idlenessTimeoutMillis != null) {
       watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
+    } else {
+      watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
+        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+        LOG.info("Assigning timestamp: {}", timestamp);
+        return timestamp;
+      }
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -191,7 +191,8 @@ public class LyftFlinkStreamingPortableTranslations {
       maxOutOfOrdernessMillis = (Number) params.get("max_out_of_orderness_millis");
     }
 
-    if (params.containsKey("idleness_timeout_millis")) {
+    if (params.containsKey("idleness_timeout_millis")
+        && params.get("idleness_timeout_millis") != null) {
       idlenessTimeoutMillis = (Number) params.get("idleness_timeout_millis");
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -239,7 +239,7 @@ public class LyftFlinkStreamingPortableTranslations {
 
     @Override
     public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<WindowedValue<byte[]>> collector) throws IOException {
-      collector.collect(WindowedValue.timestampedValueInGlobalWindow(record.value(), new Instant(record.timestamp()));
+      collector.collect(WindowedValue.timestampedValueInGlobalWindow(record.value(), new Instant(record.timestamp())));
     }
 
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -28,8 +28,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Lists;
-import com.lyft.streamingplatform.LyftKafkaConsumerBuilder;
 import com.lyft.streamingplatform.LyftKafkaProducerBuilder;
+import com.lyft.streamingplatform.LyftKafkaSourceBuilder;
+import com.lyft.streamingplatform.StartingOffsetStrategy;
 import com.lyft.streamingplatform.analytics.Event;
 import com.lyft.streamingplatform.analytics.EventField;
 import com.lyft.streamingplatform.eventssource.KinesisAndS3EventSource;
@@ -49,7 +50,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +74,8 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
@@ -83,14 +85,13 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.windowing.time.Time;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 import org.apache.flink.streaming.connectors.kinesis.util.JobManagerWatermarkTracker;
 import org.apache.flink.streaming.connectors.kinesis.util.WatermarkTracker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
+import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -161,8 +162,8 @@ public class LyftFlinkStreamingPortableTranslations {
     final String userName = (String) params.get("username");
     final String password = (String) params.get("password");
 
-    LyftKafkaConsumerBuilder<WindowedValue<byte[]>> consumerBuilder =
-        new LyftKafkaConsumerBuilder<>();
+    LyftKafkaSourceBuilder<WindowedValue<byte[]>> consumerBuilder =
+        new LyftKafkaSourceBuilder<>();
 
     consumerBuilder.withUsername(userName);
     consumerBuilder.withPassword(password);
@@ -171,16 +172,16 @@ public class LyftFlinkStreamingPortableTranslations {
     properties.putAll(consumerProps);
     consumerBuilder.withKafkaProperties(properties);
 
-    FlinkKafkaConsumer<WindowedValue<byte[]>> kafkaSource =
-        consumerBuilder.build(topics,
-            new ByteArrayWindowedValueSchema(context.getPipelineOptions()));
-
     if (params.getOrDefault("start_from_timestamp_millis", null) != null) {
-      kafkaSource.setStartFromTimestamp(
+      consumerBuilder.withStartingOffsets(
           Long.parseLong(params.get("start_from_timestamp_millis").toString()));
     } else {
-      kafkaSource.setStartFromLatest();
+      consumerBuilder.withStartingOffsets(StartingOffsetStrategy.LATEST);
     }
+
+    KafkaSource<WindowedValue<byte[]>> kafkaSource =
+        consumerBuilder.build(topics,
+            new ByteArrayWindowedValueSchema(context.getPipelineOptions()));
 
     Number maxOutOfOrdernessMillis = 1000;
     Number idlenessTimeoutMillis = null;
@@ -194,23 +195,25 @@ public class LyftFlinkStreamingPortableTranslations {
       idlenessTimeoutMillis = (Number) params.get("idleness_timeout_millis");
     }
 
+    // Define the watermark strategy
+    WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy;
     if (idlenessTimeoutMillis != null) {
-      WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy =
+      watermarkStrategy =
           WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
               Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
           .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
-      kafkaSource.assignTimestampsAndWatermarks(watermarkStrategy);
     } else {
-      kafkaSource.assignTimestampsAndWatermarks(
-          new WindowedTimestampExtractor<>(
-              Time.milliseconds(maxOutOfOrdernessMillis.longValue())));
+      watermarkStrategy =
+          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
+          .withTimestampAssigner((element, recordTimestamp) ->
+              element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
     }
 
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
         context
             .getExecutionEnvironment()
-            .addSource(kafkaSource, FlinkKafkaConsumer.class.getSimpleName() + "-" +
+            .fromSource(kafkaSource, watermarkStrategy, KafkaSource.class.getSimpleName() + "-" +
                 String.join(",", topics)));
   }
 
@@ -219,9 +222,7 @@ public class LyftFlinkStreamingPortableTranslations {
    * operators.
    */
   private static class ByteArrayWindowedValueSchema
-      implements KeyedDeserializationSchema<WindowedValue<byte[]>> {
-    private static final long serialVersionUID = -1L;
-
+      implements KafkaRecordDeserializationSchema<WindowedValue<byte[]>> {
     private final TypeInformation<WindowedValue<byte[]>> ti;
 
     public ByteArrayWindowedValueSchema(FlinkPipelineOptions pipelineOptions) {
@@ -237,21 +238,10 @@ public class LyftFlinkStreamingPortableTranslations {
     }
 
     @Override
-    public WindowedValue<byte[]> deserialize(
-        byte[] messageKey, byte[] message, String topic, int partition, long offset) {
-      throw new UnsupportedOperationException();
+    public void deserialize(ConsumerRecord<byte[], byte[]> record, Collector<WindowedValue<byte[]>> collector) throws IOException {
+      collector.collect(WindowedValue.timestampedValueInGlobalWindow(record.value(), new Instant(record.timestamp()));
     }
 
-    @Override
-    public WindowedValue<byte[]> deserialize(ConsumerRecord<byte[], byte[]> record) {
-      return WindowedValue.timestampedValueInGlobalWindow(
-          record.value(), new Instant(record.timestamp()));
-    }
-
-    @Override
-    public boolean isEndOfStream(WindowedValue<byte[]> nextElement) {
-      return false;
-    }
   }
 
   // TODO: translation assumes byte[] values, does not support keys and headers

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -203,10 +203,10 @@ public class LyftFlinkStreamingPortableTranslations {
       watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
     } else {
       watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
-        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE;
         LOG.info("Assigning timestamp: {}", timestamp);
         return timestamp;
-      }
+      });
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -184,7 +184,7 @@ public class LyftFlinkStreamingPortableTranslations {
             new ByteArrayWindowedValueSchema(context.getPipelineOptions()));
 
     Number maxOutOfOrdernessMillis = 1000;
-    Number idlenessTimeoutMillis = null;
+    Number idlenessTimeoutMillis = 30000;
 
     if (params.containsKey("max_out_of_orderness_millis")
         && params.get("max_out_of_orderness_millis") != null) {
@@ -198,16 +198,8 @@ public class LyftFlinkStreamingPortableTranslations {
     // Define the watermark strategy
     WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy =
         WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
-    if (idlenessTimeoutMillis != null) {
-      watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
-    } else {
-      watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
-        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE;
-        LOG.info("Assigning timestamp: {}", timestamp);
-        return timestamp;
-      });
-    }
+            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
+        .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
 
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -204,7 +204,8 @@ public class LyftFlinkStreamingPortableTranslations {
           .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
     } else {
       watermarkStrategy =
-          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
+          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
+              Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
           .withTimestampAssigner((element, recordTimestamp) ->
               element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
     }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslationsTest.java
@@ -55,12 +55,13 @@ import org.apache.beam.runners.flink.LyftFlinkStreamingPortableTranslations.Lyft
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.junit.Assert;
 import org.junit.Before;
@@ -214,11 +215,12 @@ public class LyftFlinkStreamingPortableTranslationsTest {
         .translateKafkaInput(id, pipeline, streamingContext);
 
     // assert
-    ArgumentCaptor<FlinkKafkaConsumer> kafkaSourceCaptor =
-        ArgumentCaptor.forClass(FlinkKafkaConsumer.class);
+    ArgumentCaptor<KafkaSource> kafkaSourceCaptor =
+        ArgumentCaptor.forClass(KafkaSource.class);
+    ArgumentCaptor<WatermarkStrategy> kafkaWatermarkStrategyCaptor = ArgumentCaptor.forClass(WatermarkStrategy.class);
     ArgumentCaptor<String> kafkaSourceNameCaptor = ArgumentCaptor.forClass(String.class);
     verify(streamingEnvironment)
-        .addSource(kafkaSourceCaptor.capture(), kafkaSourceNameCaptor.capture());
+        .fromSource(kafkaSourceCaptor.capture(), kafkaWatermarkStrategyCaptor.capture(), kafkaSourceNameCaptor.capture());
     Assert.assertEquals(
         WindowedValue.class, kafkaSourceCaptor.getValue().getProducedType().getTypeClass());
     Assert.assertTrue(kafkaSourceNameCaptor.getValue().contains(topicName));


### PR DESCRIPTION
This pull request includes significant updates to the `runners/flink` module, primarily focusing on upgrading dependencies and refactoring the Kafka-related code to use updated classes and methods. The most important changes include updating the dependencies in `flink_runner.gradle`, refactoring the `LyftFlinkStreamingPortableTranslations` class to use the `LyftKafkaSourceBuilder` and `KafkaSource`, and modifying the `ByteArrayWindowedValueSchema` class to implement `KafkaRecordDeserializationSchema`.