### PR TITLE
Use withIdleness by default

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -196,18 +196,11 @@ public class LyftFlinkStreamingPortableTranslations {
     }
 
     // Define the watermark strategy
-    WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy;
+    WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy =
+        WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
+            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
     if (idlenessTimeoutMillis != null) {
-      watermarkStrategy =
-          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-              Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
-          .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
-    } else {
-      watermarkStrategy =
-          WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-              Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
-          .withTimestampAssigner((element, recordTimestamp) ->
-              element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+      watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -201,6 +201,12 @@ public class LyftFlinkStreamingPortableTranslations {
             Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
     if (idlenessTimeoutMillis != null) {
       watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
+    } else {
+      watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
+        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+        LOG.info("Assigning timestamp: {}", timestamp);
+        return timestamp;
+      }
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -191,7 +191,8 @@ public class LyftFlinkStreamingPortableTranslations {
       maxOutOfOrdernessMillis = (Number) params.get("max_out_of_orderness_millis");
     }
 
-    if (params.containsKey("idleness_timeout_millis")) {
+    if (params.containsKey("idleness_timeout_millis")
+        && params.get("idleness_timeout_millis") != null) {
       idlenessTimeoutMillis = (Number) params.get("idleness_timeout_millis");
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -203,10 +203,10 @@ public class LyftFlinkStreamingPortableTranslations {
       watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
     } else {
       watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
-        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE);
+        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE;
         LOG.info("Assigning timestamp: {}", timestamp);
         return timestamp;
-      }
+      });
     }
 
     context.addDataStream(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/LyftFlinkStreamingPortableTranslations.java
@@ -184,7 +184,7 @@ public class LyftFlinkStreamingPortableTranslations {
             new ByteArrayWindowedValueSchema(context.getPipelineOptions()));
 
     Number maxOutOfOrdernessMillis = 1000;
-    Number idlenessTimeoutMillis = null;
+    Number idlenessTimeoutMillis = 30000;
 
     if (params.containsKey("max_out_of_orderness_millis")
         && params.get("max_out_of_orderness_millis") != null) {
@@ -198,16 +198,8 @@ public class LyftFlinkStreamingPortableTranslations {
     // Define the watermark strategy
     WatermarkStrategy<WindowedValue<byte[]>> watermarkStrategy =
         WatermarkStrategy.<WindowedValue<byte[]>>forBoundedOutOfOrderness(
-            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()));
-    if (idlenessTimeoutMillis != null) {
-      watermarkStrategy = watermarkStrategy.withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
-    } else {
-      watermarkStrategy = watermarkStrategy.withTimestampAssigner((element, recordTimestamp) -> {
-        long timestamp = element.getTimestamp() != null ? element.getTimestamp().getMillis() : Long.MIN_VALUE;
-        LOG.info("Assigning timestamp: {}", timestamp);
-        return timestamp;
-      });
-    }
+            Duration.ofMillis(maxOutOfOrdernessMillis.longValue()))
+        .withIdleness(Duration.ofMillis(idlenessTimeoutMillis.longValue()));
 
     context.addDataStream(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),


### PR DESCRIPTION
With the new `KafkaSource`, when `idlenessTimeoutMillis` is null, pipelines aren't outputting results as expected.

Specifically watermarks are not propagated when `parallelism > numKafkaShards`. This can be fixed by always using `withIdleness`.

Tested using version `2.50.0-lyft202502201740098631dev`.